### PR TITLE
tenancy: add polling library and update project resolution for Nexus replacement

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/hashicorp/vault/api v1.14.0
@@ -53,7 +54,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go/pkg/middleware/projectcontext/projeccontext_test.go
+++ b/go/pkg/middleware/projectcontext/projeccontext_test.go
@@ -110,7 +110,7 @@ func TestResolveProjectUUID(t *testing.T) {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "Bearer token123", r.Header.Get("Authorization"))
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode([]struct {
+				_ = json.NewEncoder(w).Encode(struct {
 					Name   string `json:"name"`
 					Status struct {
 						ProjectStatus struct {
@@ -118,18 +118,16 @@ func TestResolveProjectUUID(t *testing.T) {
 						} `json:"projectStatus"`
 					} `json:"status"`
 				}{
-					{
-						Name: "test-project",
-						Status: struct {
-							ProjectStatus struct {
-								UID string `json:"uID"`
-							} `json:"projectStatus"`
+					Name: "test-project",
+					Status: struct {
+						ProjectStatus struct {
+							UID string `json:"uID"`
+						} `json:"projectStatus"`
+					}{
+						ProjectStatus: struct {
+							UID string `json:"uID"`
 						}{
-							ProjectStatus: struct {
-								UID string `json:"uID"`
-							}{
-								UID: "uuid-123",
-							},
+							UID: "uuid-123",
 						},
 					},
 				})
@@ -142,30 +140,7 @@ func TestResolveProjectUUID(t *testing.T) {
 			projectName: "non-existent",
 			authHeader:  "Bearer token123",
 			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode([]struct {
-					Name   string `json:"name"`
-					Status struct {
-						ProjectStatus struct {
-							UID string `json:"uID"`
-						} `json:"projectStatus"`
-					} `json:"status"`
-				}{
-					{
-						Name: "other-project",
-						Status: struct {
-							ProjectStatus struct {
-								UID string `json:"uID"`
-							} `json:"projectStatus"`
-						}{
-							ProjectStatus: struct {
-								UID string `json:"uID"`
-							}{
-								UID: "uuid-456",
-							},
-						},
-					},
-				})
+				w.WriteHeader(http.StatusNotFound)
 			},
 			expectError:   true,
 			errorContains: "project not found: non-existent",
@@ -178,7 +153,7 @@ func TestResolveProjectUUID(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
 			expectError:   true,
-			errorContains: "Nexus API returned status 500",
+			errorContains: "tenant manager returned status 500",
 		},
 		{
 			name:        "invalid JSON response",
@@ -197,15 +172,7 @@ func TestResolveProjectUUID(t *testing.T) {
 			authHeader:  "",
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				assert.Empty(t, r.Header.Get("Authorization"))
-				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode([]struct {
-					Name   string `json:"name"`
-					Status struct {
-						ProjectStatus struct {
-							UID string `json:"uID"`
-						} `json:"projectStatus"`
-					} `json:"status"`
-				}{})
+				w.WriteHeader(http.StatusNotFound)
 			},
 			expectError:   true,
 			errorContains: "project not found",
@@ -289,15 +256,7 @@ func TestResolveAndValidateProjectID(t *testing.T) {
 			},
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode([]struct {
-						Name   string `json:"name"`
-						Status struct {
-							ProjectStatus struct {
-								UID string `json:"uID"`
-							} `json:"projectStatus"`
-						} `json:"status"`
-					}{})
+					w.WriteHeader(http.StatusNotFound)
 				}))
 			},
 			expectError:   true,
@@ -368,7 +327,7 @@ func TestInjectActiveProjectID(t *testing.T) {
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode([]struct {
+					_ = json.NewEncoder(w).Encode(struct {
 						Name   string `json:"name"`
 						Status struct {
 							ProjectStatus struct {
@@ -376,18 +335,16 @@ func TestInjectActiveProjectID(t *testing.T) {
 							} `json:"projectStatus"`
 						} `json:"status"`
 					}{
-						{
-							Name: "test-project",
-							Status: struct {
-								ProjectStatus struct {
-									UID string `json:"uID"`
-								} `json:"projectStatus"`
+						Name: "test-project",
+						Status: struct {
+							ProjectStatus struct {
+								UID string `json:"uID"`
+							} `json:"projectStatus"`
+						}{
+							ProjectStatus: struct {
+								UID string `json:"uID"`
 							}{
-								ProjectStatus: struct {
-									UID string `json:"uID"`
-								}{
-									UID: "11111111-1111-1111-1111-111111111111",
-								},
+								UID: "11111111-1111-1111-1111-111111111111",
 							},
 						},
 					})
@@ -432,7 +389,7 @@ func TestInjectActiveProjectID(t *testing.T) {
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode([]struct {
+					_ = json.NewEncoder(w).Encode(struct {
 						Name   string `json:"name"`
 						Status struct {
 							ProjectStatus struct {
@@ -440,18 +397,16 @@ func TestInjectActiveProjectID(t *testing.T) {
 							} `json:"projectStatus"`
 						} `json:"status"`
 					}{
-						{
-							Name: "test-project",
-							Status: struct {
-								ProjectStatus struct {
-									UID string `json:"uID"`
-								} `json:"projectStatus"`
+						Name: "test-project",
+						Status: struct {
+							ProjectStatus struct {
+								UID string `json:"uID"`
+							} `json:"projectStatus"`
+						}{
+							ProjectStatus: struct {
+								UID string `json:"uID"`
 							}{
-								ProjectStatus: struct {
-									UID string `json:"uID"`
-								}{
-									UID: "55555555-5555-5555-5555-555555555555",
-								},
+								UID: "55555555-5555-5555-5555-555555555555",
 							},
 						},
 					})

--- a/go/pkg/middleware/projectcontext/projeccontext_test.go
+++ b/go/pkg/middleware/projectcontext/projeccontext_test.go
@@ -18,10 +18,14 @@ import (
 func bearerJWTWithProjectRole(t *testing.T, projectUUID string) string {
 	t.Helper()
 
+	// Role format: {projectUUID}_{roleName}
+	// The auth package looks for UUIDs in the first segment before "_"
+	role := projectUUID + "_member-role"
+
 	headerJSON := []byte(`{"alg":"none","typ":"JWT"}`)
 	payload, err := json.Marshal(map[string]interface{}{
 		"realm_access": map[string]interface{}{
-			"roles": []interface{}{projectUUID + "_some-role"},
+			"roles": []interface{}{role},
 		},
 	})
 	require.NoError(t, err)
@@ -106,9 +110,12 @@ func TestResolveProjectUUID(t *testing.T) {
 		{
 			name:        "successful project resolution",
 			projectName: "test-project",
-			authHeader:  "Bearer token123",
+			// Generate a valid JWT with the project UUID in roles for defense-in-depth validation
+			// Use a valid UUID format (required by auth.ValidateProjectAccess)
+			authHeader: bearerJWTWithProjectRole(t, "123e4567-e89b-12d3-a456-426614174000"),
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "Bearer token123", r.Header.Get("Authorization"))
+				// Verify auth header is forwarded
+				assert.NotEmpty(t, r.Header.Get("Authorization"))
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(struct {
 					Name   string `json:"name"`
@@ -127,13 +134,13 @@ func TestResolveProjectUUID(t *testing.T) {
 						ProjectStatus: struct {
 							UID string `json:"uID"`
 						}{
-							UID: "uuid-123",
+							UID: "123e4567-e89b-12d3-a456-426614174000",
 						},
 					},
 				})
 			},
 			expectError:  false,
-			expectedUUID: "uuid-123",
+			expectedUUID: "123e4567-e89b-12d3-a456-426614174000",
 		},
 		{
 			name:        "project not found",

--- a/go/pkg/middleware/projectcontext/projeccontext_test.go
+++ b/go/pkg/middleware/projectcontext/projeccontext_test.go
@@ -174,6 +174,18 @@ func TestResolveProjectUUID(t *testing.T) {
 			errorContains: "failed to decode response",
 		},
 		{
+			name:        "200 response with empty UUID is a hard failure",
+			projectName: "test-project",
+			authHeader:  "Bearer token123",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				// Partial/malformed response: status.projectStatus.uID is missing
+				_, _ = w.Write([]byte(`{"name":"test-project","status":{"projectStatus":{}}}`))
+			},
+			expectError:   true,
+			errorContains: "empty project UUID",
+		},
+		{
 			name:        "empty auth header",
 			projectName: "test-project",
 			authHeader:  "",

--- a/go/pkg/middleware/projectcontext/projectcontext.go
+++ b/go/pkg/middleware/projectcontext/projectcontext.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
+	"time"
 
 	"github.com/open-edge-platform/orch-library/go/pkg/auth"
 )
@@ -20,7 +22,13 @@ const (
 	pathProjectPattern = `^/v[0-9]+/projects/([^/]+)/`
 )
 
-var projectPathRegex = regexp.MustCompile(pathProjectPattern)
+var (
+	projectPathRegex = regexp.MustCompile(pathProjectPattern)
+
+	// sharedHTTPClient is reused across all ResolveProjectUUID calls to
+	// benefit from connection pooling to the Tenant Manager.
+	sharedHTTPClient = &http.Client{Timeout: 10 * time.Second}
+)
 
 // ExtractProjectNameFromPath extracts the project name from the given context
 func ExtractProjectNameFromPath(path string) string {
@@ -31,10 +39,13 @@ func ExtractProjectNameFromPath(path string) string {
 	return ""
 }
 
-// ResolveProjectUUID queries the Tenant Manager API to resolve project UUID from project name.
-// Calls GET /v1/projects/{name} directly for O(1) lookup instead of listing all projects.
+// ResolveProjectUUID resolves a project name to its UUID by calling
+// GET /v1/projects/{name} on the Tenant Manager. The Tenant Manager enforces
+// JWT-based RBAC internally: it checks that the caller has project-read-role
+// or member-role within the appropriate org. Forwarding the Authorization
+// header is sufficient — no additional filter parameters are required.
 func ResolveProjectUUID(ctx context.Context, projectName string, authHeader string, projectServiceURL string) (string, error) {
-	reqURL := fmt.Sprintf("%s/v1/projects/%s", projectServiceURL, projectName)
+	reqURL := fmt.Sprintf("%s/v1/projects/%s", projectServiceURL, url.PathEscape(projectName))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -45,8 +56,7 @@ func ResolveProjectUUID(ctx context.Context, projectName string, authHeader stri
 		req.Header.Set("Authorization", authHeader)
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := sharedHTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to query tenant manager: %w", err)
 	}

--- a/go/pkg/middleware/projectcontext/projectcontext.go
+++ b/go/pkg/middleware/projectcontext/projectcontext.go
@@ -42,8 +42,11 @@ func ExtractProjectNameFromPath(path string) string {
 // ResolveProjectUUID resolves a project name to its UUID by calling
 // GET /v1/projects/{name} on the Tenant Manager. The Tenant Manager enforces
 // JWT-based RBAC internally: it checks that the caller has project-read-role
-// or member-role within the appropriate org. Forwarding the Authorization
-// header is sufficient — no additional filter parameters are required.
+// or member-role within the appropriate org.
+//
+// This function also validates that the caller has access
+// to the returned project UUID by checking JWT claims. This protects against
+// misconfigured Tenant Manager auth middleware or direct ClusterIP access.
 func ResolveProjectUUID(ctx context.Context, projectName string, authHeader string, projectServiceURL string) (string, error) {
 	reqURL := fmt.Sprintf("%s/v1/projects/%s", projectServiceURL, url.PathEscape(projectName))
 
@@ -82,7 +85,18 @@ func ResolveProjectUUID(ctx context.Context, projectName string, authHeader stri
 		return "", fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return project.Status.ProjectStatus.UID, nil
+	projectUUID := project.Status.ProjectStatus.UID
+
+	// This function also validates that the caller has access to this project via JWT claims.
+	// The Tenant Manager should have already enforced this, but we verify
+	// client-side to protect against misconfiguration or direct ClusterIP access.
+	if projectUUID != "" && authHeader != "" {
+		if err := auth.ValidateProjectAccess(authHeader, projectUUID); err != nil {
+			return "", fmt.Errorf("access denied to project %s: %w", projectName, err)
+		}
+	}
+
+	return projectUUID, nil
 }
 
 // ProjectResolverConfig holds configuration for project resolution and validation

--- a/go/pkg/middleware/projectcontext/projectcontext.go
+++ b/go/pkg/middleware/projectcontext/projectcontext.go
@@ -114,13 +114,13 @@ type ProjectResolverConfig struct {
 
 // ResolveAndValidateProjectID is a framework-agnostic helper that resolves and validates
 // project ID from request path and auth header. It performs:
-// 1. Extract project name from path
-// 2. Resolve project UUID via project service (Nexus) API
-// 3. Validate user has access to the project
-// 4. Fall back to JWT extraction for old-style paths
+//  1. Extract project name from path
+//  2. Resolve project UUID via Tenant Manager REST API
+//     — ResolveProjectUUID also verifies JWT access
+//  3. Fall back to JWT extraction for old-style paths
 //
 // Returns (projectUUID, error) - error is non-nil only if ErrorOnMissingProject is true
-// and the project cannot be resolved or user doesn't have access.
+// and the project cannot be resolved or the caller does not have access.
 func ResolveAndValidateProjectID(ctx context.Context, path string, authHeader string, existingProjectID string, config ProjectResolverConfig) (string, error) {
 	if existingProjectID != "" {
 		return existingProjectID, nil // Already set, no need to resolve
@@ -131,6 +131,8 @@ func ResolveAndValidateProjectID(ctx context.Context, path string, authHeader st
 
 	if projectName != "" {
 		// New-style path: /v1/projects/{projectName}/...
+		// ResolveProjectUUID performs the Tenant Manager lookup and enforces
+		// JWT-based access validation internally.
 		projectUUID, err := ResolveProjectUUID(ctx, projectName, authHeader, config.ProjectServiceURL)
 		if err != nil {
 			if config.ErrorOnMissingProject {
@@ -138,17 +140,7 @@ func ResolveAndValidateProjectID(ctx context.Context, path string, authHeader st
 			}
 			return "", nil
 		}
-
-		if projectUUID != "" {
-			// Validate user has access to this project
-			if err := auth.ValidateProjectAccess(authHeader, projectUUID); err != nil {
-				if config.ErrorOnMissingProject {
-					return "", fmt.Errorf("access denied to project %s: %w", projectName, err)
-				}
-				return "", nil
-			}
-			return projectUUID, nil
-		}
+		return projectUUID, nil
 	} else if authHeader != "" {
 		// Old-style path: /edge-infra.orchestrator.apis/v2/...
 		// Extract project UUID from JWT token roles

--- a/go/pkg/middleware/projectcontext/projectcontext.go
+++ b/go/pkg/middleware/projectcontext/projectcontext.go
@@ -50,7 +50,7 @@ func ExtractProjectNameFromPath(path string) string {
 func ResolveProjectUUID(ctx context.Context, projectName string, authHeader string, projectServiceURL string) (string, error) {
 	reqURL := fmt.Sprintf("%s/v1/projects/%s", projectServiceURL, url.PathEscape(projectName))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil) //nolint:gosec // projectServiceURL is a configured service URL, not user input; projectName is PathEscaped
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -59,7 +59,7 @@ func ResolveProjectUUID(ctx context.Context, projectName string, authHeader stri
 		req.Header.Set("Authorization", authHeader)
 	}
 
-	resp, err := sharedHTTPClient.Do(req)
+	resp, err := sharedHTTPClient.Do(req) //nolint:gosec // URL constructed from configured service endpoint with escaped path
 	if err != nil {
 		return "", fmt.Errorf("failed to query tenant manager: %w", err)
 	}
@@ -87,10 +87,17 @@ func ResolveProjectUUID(ctx context.Context, projectName string, authHeader stri
 
 	projectUUID := project.Status.ProjectStatus.UID
 
-	// This function also validates that the caller has access to this project via JWT claims.
+	// A 200 response with an empty UUID means the Tenant Manager returned a
+	// malformed/partial response. Treat this as a hard failure rather than
+	// silently returning empty string (which callers interpret as "no project").
+	if projectUUID == "" {
+		return "", fmt.Errorf("tenant manager returned empty project UUID for %s", projectName)
+	}
+
+	// Validate user has access to this project via JWT claims.
 	// The Tenant Manager should have already enforced this, but we verify
 	// client-side to protect against misconfiguration or direct ClusterIP access.
-	if projectUUID != "" && authHeader != "" {
+	if authHeader != "" {
 		if err := auth.ValidateProjectAccess(authHeader, projectUUID); err != nil {
 			return "", fmt.Errorf("access denied to project %s: %w", projectName, err)
 		}

--- a/go/pkg/middleware/projectcontext/projectcontext.go
+++ b/go/pkg/middleware/projectcontext/projectcontext.go
@@ -31,9 +31,10 @@ func ExtractProjectNameFromPath(path string) string {
 	return ""
 }
 
-// ResolveProjectUUID queries the project service API to resolve project UUID from project name
+// ResolveProjectUUID queries the Tenant Manager API to resolve project UUID from project name.
+// Calls GET /v1/projects/{name} directly for O(1) lookup instead of listing all projects.
 func ResolveProjectUUID(ctx context.Context, projectName string, authHeader string, projectServiceURL string) (string, error) {
-	reqURL := fmt.Sprintf("%s/v1/projects?member-role=true", projectServiceURL)
+	reqURL := fmt.Sprintf("%s/v1/projects/%s", projectServiceURL, projectName)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -47,15 +48,18 @@ func ResolveProjectUUID(ctx context.Context, projectName string, authHeader stri
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to query Nexus API: %w", err)
+		return "", fmt.Errorf("failed to query tenant manager: %w", err)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return "", fmt.Errorf("project not found: %s", projectName)
+	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Nexus API returned status %d", resp.StatusCode) //nolint:staticcheck
+		return "", fmt.Errorf("tenant manager returned status %d", resp.StatusCode)
 	}
 
-	var projects []struct {
+	var project struct {
 		Name   string `json:"name"`
 		Status struct {
 			ProjectStatus struct {
@@ -64,17 +68,11 @@ func ResolveProjectUUID(ctx context.Context, projectName string, authHeader stri
 		} `json:"status"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&projects); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&project); err != nil {
 		return "", fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	for _, project := range projects {
-		if project.Name == projectName {
-			return project.Status.ProjectStatus.UID, nil
-		}
-	}
-
-	return "", fmt.Errorf("project not found: %s", projectName)
+	return project.Status.ProjectStatus.UID, nil
 }
 
 // ProjectResolverConfig holds configuration for project resolution and validation

--- a/go/pkg/tenancy/poller.go
+++ b/go/pkg/tenancy/poller.go
@@ -246,6 +246,18 @@ func (p *Poller) processEvent(ctx context.Context, event Event) error {
 	log.Debugf("tenancy processEvent: controller=%s type=%s/%s resource=%s id=%d",
 		p.controllerName, event.ResourceType, event.EventType, event.ResourceName, event.ID)
 
+	// Sanity check: a malformed event with a zero ResourceID would cause every
+	// downstream operation (status updates keyed by resource_id, namespace
+	// creation, Keycloak group lookup, etc.) to either no-op silently or
+	// affect the wrong resource. Reject it here so handlers don't have to
+	// repeat this defense.
+	if event.ResourceID == uuid.Nil {
+		err := fmt.Errorf("tenancy event has zero ResourceID (controller=%s event_id=%d type=%s/%s name=%q)",
+			p.controllerName, event.ID, event.ResourceType, event.EventType, event.ResourceName)
+		p.logError(err, "dropping malformed event")
+		return err
+	}
+
 	// Set status to in_progress. Log failure but continue processing.
 	if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusInProgress, ""); err != nil {
 		p.logError(err, fmt.Sprintf("failed to set in_progress status for %s/%s (controller=%s)",

--- a/go/pkg/tenancy/poller.go
+++ b/go/pkg/tenancy/poller.go
@@ -175,6 +175,10 @@ func (p *Poller) replayWithRetry(ctx context.Context) (int64, error) {
 }
 
 // replay fetches synthesized events and processes them.
+// Returns an error if any event fails — the caller (replayWithRetry) will
+// retry the whole replay until all synthesized events are successfully processed.
+// Unlike poll(), partial progress is not tracked: the replay endpoint
+// re-synthesizes the full snapshot on each call, so retrying from scratch is safe.
 func (p *Poller) replay(ctx context.Context) (int64, error) {
 	tmURL := fmt.Sprintf("%s/v1/events?controller=%s&replay=true",
 		p.tenantManagerURL, url.QueryEscape(p.controllerName))
@@ -189,8 +193,8 @@ func (p *Poller) replay(ctx context.Context) (int64, error) {
 
 	for _, event := range resp.Events {
 		if err := p.processEvent(ctx, event); err != nil {
-			p.logError(err, fmt.Sprintf("replay event %s %s/%s failed (controller=%s)",
-				event.EventType, event.ResourceType, event.ResourceName, p.controllerName))
+			return 0, fmt.Errorf("replay event %s %s/%s failed (controller=%s): %w",
+				event.EventType, event.ResourceType, event.ResourceName, p.controllerName, err)
 		}
 	}
 

--- a/go/pkg/tenancy/poller.go
+++ b/go/pkg/tenancy/poller.go
@@ -71,7 +71,8 @@ type Poller struct {
 // they are ClusterIP-only and the Tenant Manager enforces in-cluster network
 // policy rather than JWT validation on these routes.
 //
-// Returns an error if tenantManagerURL or controllerName is empty.
+// Returns an error if tenantManagerURL or controllerName is empty, or if
+// the resulting config is invalid.
 func NewPoller(tenantManagerURL, controllerName string, handler Handler, opts ...func(*PollerConfig)) (*Poller, error) {
 	if tenantManagerURL == "" {
 		return nil, fmt.Errorf("tenantManagerURL must not be empty")
@@ -86,6 +87,24 @@ func NewPoller(tenantManagerURL, controllerName string, handler Handler, opts ..
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+
+	// Validate config after applying options.
+	if cfg.PollInterval <= 0 {
+		return nil, fmt.Errorf("PollInterval must be positive, got %s", cfg.PollInterval)
+	}
+	if cfg.PollLimit <= 0 {
+		return nil, fmt.Errorf("PollLimit must be positive, got %d", cfg.PollLimit)
+	}
+	if cfg.InitialBackoff <= 0 {
+		return nil, fmt.Errorf("InitialBackoff must be positive, got %s", cfg.InitialBackoff)
+	}
+	if cfg.MaxBackoff <= 0 {
+		return nil, fmt.Errorf("MaxBackoff must be positive, got %s", cfg.MaxBackoff)
+	}
+	if cfg.HTTPTimeout <= 0 {
+		return nil, fmt.Errorf("HTTPTimeout must be positive, got %s", cfg.HTTPTimeout)
+	}
+
 	return &Poller{
 		tenantManagerURL: tenantManagerURL,
 		controllerName:   controllerName,
@@ -179,6 +198,9 @@ func (p *Poller) replay(ctx context.Context) (int64, error) {
 }
 
 // poll fetches incremental events after lastEventID and processes them.
+// Returns the last successfully processed event ID. If any event fails,
+// stops processing and returns the ID of the last successful event so that
+// failed events will be retried on the next poll (at-least-once semantics).
 func (p *Poller) poll(ctx context.Context, lastEventID int64) (int64, error) {
 	tmURL := fmt.Sprintf("%s/v1/events?controller=%s&after=%d&limit=%d",
 		p.tenantManagerURL, url.QueryEscape(p.controllerName), lastEventID, p.config.PollLimit)
@@ -193,23 +215,34 @@ func (p *Poller) poll(ctx context.Context, lastEventID int64) (int64, error) {
 			p.controllerName, len(resp.Events), resp.LastEventID)
 	}
 
+	// Process events sequentially. Stop at first error to preserve
+	// at-least-once semantics (failed event will be retried on next poll).
+	processedLastEventID := lastEventID
 	for _, event := range resp.Events {
 		if err := p.processEvent(ctx, event); err != nil {
-			p.logError(err, fmt.Sprintf("event %s %s/%s failed (controller=%s)",
+			p.logError(err, fmt.Sprintf("event %s %s/%s failed (controller=%s), will retry on next poll",
 				event.EventType, event.ResourceType, event.ResourceName, p.controllerName))
+			return processedLastEventID, nil
 		}
+		processedLastEventID = event.ID
 	}
 
-	return resp.LastEventID, nil
+	return processedLastEventID, nil
 }
 
 // processEvent handles a single event: set in_progress, call handler,
 // then update status or delete status row.
+//
+// Status update failures are logged but do NOT cause event processing to fail.
+// This prevents temporary Tenant Manager unavailability from blocking event
+// processing. The tradeoff: status may briefly be stale until the next successful
+// status update (on replay or next event). Controllers must be idempotent to
+// handle replay reconciliation.
 func (p *Poller) processEvent(ctx context.Context, event Event) error {
 	log.Debugf("tenancy processEvent: controller=%s type=%s/%s resource=%s id=%d",
 		p.controllerName, event.ResourceType, event.EventType, event.ResourceName, event.ID)
 
-	// Set status to in_progress.
+	// Set status to in_progress. Log failure but continue processing.
 	if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusInProgress, ""); err != nil {
 		p.logError(err, fmt.Sprintf("failed to set in_progress status for %s/%s (controller=%s)",
 			event.ResourceType, event.ResourceName, p.controllerName))
@@ -225,10 +258,19 @@ func (p *Poller) processEvent(ctx context.Context, event Event) error {
 	if event.EventType == EventTypeDeleted {
 		if handleErr == nil {
 			// Success: delete the status row (analogous to DeleteActiveWatchers in Nexus).
-			return p.deleteStatus(ctx, event.ResourceType, event.ResourceID)
+			// Status delete failure is logged but doesn't fail the event.
+			if err := p.deleteStatus(ctx, event.ResourceType, event.ResourceID); err != nil {
+				p.logError(err, fmt.Sprintf("failed to delete status for %s/%s (controller=%s)",
+					event.ResourceType, event.ResourceName, p.controllerName))
+			}
+			return nil
 		}
 		// Error on delete: set error status (row remains for visibility).
-		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error())
+		// Status update failure is logged but we still return the handler error.
+		if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error()); err != nil {
+			p.logError(err, fmt.Sprintf("failed to set error status for %s/%s (controller=%s)",
+				event.ResourceType, event.ResourceName, p.controllerName))
+		}
 		return handleErr
 	}
 
@@ -237,7 +279,12 @@ func (p *Poller) processEvent(ctx context.Context, event Event) error {
 		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error())
 		return handleErr
 	}
-	return p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusCompleted, "")
+	statusErr := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusCompleted, "")
+	if statusErr != nil {
+		p.logError(statusErr, fmt.Sprintf("failed to set completed status for %s/%s (controller=%s)",
+			event.ResourceType, event.ResourceName, p.controllerName))
+	}
+	return nil
 }
 
 func (p *Poller) logError(err error, msg string) {

--- a/go/pkg/tenancy/poller.go
+++ b/go/pkg/tenancy/poller.go
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tenancy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PollerConfig controls Poller behavior.
+type PollerConfig struct {
+	// PollInterval is the steady-state polling interval (default 5s).
+	PollInterval time.Duration
+
+	// PollLimit is the max number of events per poll request (default 100).
+	PollLimit int
+
+	// InitialBackoff is the starting backoff when the Tenant Manager is
+	// unreachable (default 1s).
+	InitialBackoff time.Duration
+
+	// MaxBackoff caps the exponential backoff (default 30s).
+	MaxBackoff time.Duration
+
+	// OnError is called when a non-fatal error occurs (poll failure,
+	// event processing error, status update failure). If nil, errors
+	// are silently ignored. The Poller continues regardless.
+	OnError func(err error, msg string)
+}
+
+// DefaultPollerConfig returns sensible defaults.
+func DefaultPollerConfig() PollerConfig {
+	return PollerConfig{
+		PollInterval:   5 * time.Second,
+		PollLimit:      100,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+}
+
+// Poller manages the full Watch lifecycle: replay on startup, then
+// steady-state polling. It calls the Handler for each event and manages
+// controller status updates automatically.
+type Poller struct {
+	tenantManagerURL string
+	controllerName   string
+	handler          Handler
+	config           PollerConfig
+	client           *http.Client
+}
+
+// NewPoller creates a Poller. controllerName must be the canonical ID
+// from the registered-controller config (e.g., "app-orch-tenant-controller").
+func NewPoller(tenantManagerURL, controllerName string, handler Handler, opts ...func(*PollerConfig)) *Poller {
+	cfg := DefaultPollerConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Poller{
+		tenantManagerURL: tenantManagerURL,
+		controllerName:   controllerName,
+		handler:          handler,
+		config:           cfg,
+		client:           &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Run executes replay (Phase 1), then enters steady-state polling
+// (Phase 2). Blocks until ctx is cancelled. On restart, replays from
+// scratch. Handlers must be idempotent.
+func (p *Poller) Run(ctx context.Context) error {
+	// Phase 1: Replay with backoff retry.
+	lastEventID, err := p.replayWithRetry(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Phase 2: Steady-state polling.
+	ticker := time.NewTicker(p.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			newLastID, err := p.poll(ctx, lastEventID)
+			if err != nil {
+				p.logError(err, "poll failed, will retry next interval")
+				continue
+			}
+			lastEventID = newLastID
+		}
+	}
+}
+
+// replayWithRetry retries the replay request with exponential backoff
+// until the Tenant Manager is available.
+func (p *Poller) replayWithRetry(ctx context.Context) (int64, error) {
+	backoff := p.config.InitialBackoff
+
+	for {
+		lastEventID, err := p.replay(ctx)
+		if err == nil {
+			return lastEventID, nil
+		}
+
+		p.logError(err, fmt.Sprintf("replay failed, retrying in %s", backoff))
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > p.config.MaxBackoff {
+			backoff = p.config.MaxBackoff
+		}
+	}
+}
+
+// replay fetches synthesized events and processes them.
+func (p *Poller) replay(ctx context.Context) (int64, error) {
+	url := fmt.Sprintf("%s/v1/events?controller=%s&replay=true",
+		p.tenantManagerURL, p.controllerName)
+
+	resp, err := p.doGet(ctx, url)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, event := range resp.Events {
+		if err := p.processEvent(ctx, event); err != nil {
+			p.logError(err, fmt.Sprintf("replay event %s %s/%s failed",
+				event.EventType, event.ResourceType, event.ResourceName))
+		}
+	}
+
+	return resp.LastEventID, nil
+}
+
+// poll fetches incremental events after lastEventID and processes them.
+func (p *Poller) poll(ctx context.Context, lastEventID int64) (int64, error) {
+	url := fmt.Sprintf("%s/v1/events?controller=%s&after=%d&limit=%d",
+		p.tenantManagerURL, p.controllerName, lastEventID, p.config.PollLimit)
+
+	resp, err := p.doGet(ctx, url)
+	if err != nil {
+		return lastEventID, err
+	}
+
+	for _, event := range resp.Events {
+		if err := p.processEvent(ctx, event); err != nil {
+			p.logError(err, fmt.Sprintf("event %s %s/%s failed",
+				event.EventType, event.ResourceType, event.ResourceName))
+		}
+	}
+
+	return resp.LastEventID, nil
+}
+
+// processEvent handles a single event: set in_progress, call handler,
+// then update status or delete status row.
+func (p *Poller) processEvent(ctx context.Context, event Event) error {
+	// Set status to in_progress.
+	if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, "in_progress", ""); err != nil {
+		p.logError(err, "failed to set in_progress status")
+	}
+
+	// Call the controller's handler.
+	handleErr := p.handler.HandleEvent(ctx, event)
+
+	if event.EventType == "deleted" {
+		if handleErr == nil {
+			// Success: delete the status row.
+			return p.deleteStatus(ctx, event.ResourceType, event.ResourceID)
+		}
+		// Error on delete: set error status (don't delete the row).
+		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, "error", handleErr.Error())
+		return handleErr
+	}
+
+	// Created event.
+	if handleErr != nil {
+		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, "error", handleErr.Error())
+		return handleErr
+	}
+	return p.updateStatus(ctx, event.ResourceType, event.ResourceID, "completed", "")
+}
+
+func (p *Poller) logError(err error, msg string) {
+	if p.config.OnError != nil {
+		p.config.OnError(err, msg)
+	}
+}
+
+// --- HTTP helpers ---
+
+func (p *Poller) doGet(ctx context.Context, url string) (*eventsResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("tenant manager returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result eventsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode events response: %w", err)
+	}
+	return &result, nil
+}
+
+func (p *Poller) updateStatus(ctx context.Context, resourceType string, resourceID uuid.UUID, status, message string) error {
+	body := statusUpdateRequest{
+		Controller:   p.controllerName,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+		Status:       status,
+		Message:      message,
+	}
+	return p.doJSON(ctx, http.MethodPut, p.tenantManagerURL+"/v1/status", body)
+}
+
+func (p *Poller) deleteStatus(ctx context.Context, resourceType string, resourceID uuid.UUID) error {
+	body := statusDeleteRequest{
+		Controller:   p.controllerName,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+	}
+	return p.doJSON(ctx, http.MethodDelete, p.tenantManagerURL+"/v1/status", body)
+}
+
+func (p *Poller) doJSON(ctx context.Context, method, url string, body interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/go/pkg/tenancy/poller.go
+++ b/go/pkg/tenancy/poller.go
@@ -276,7 +276,10 @@ func (p *Poller) processEvent(ctx context.Context, event Event) error {
 
 	// Created event.
 	if handleErr != nil {
-		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error())
+		if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error()); err != nil {
+			p.logError(err, fmt.Sprintf("failed to set error status for %s/%s (controller=%s)",
+				event.ResourceType, event.ResourceName, p.controllerName))
+		}
 		return handleErr
 	}
 	statusErr := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusCompleted, "")

--- a/go/pkg/tenancy/poller.go
+++ b/go/pkg/tenancy/poller.go
@@ -11,10 +11,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/open-edge-platform/orch-library/go/dazl"
 )
+
+var log = dazl.GetLogger()
 
 // PollerConfig controls Poller behavior.
 type PollerConfig struct {
@@ -31,9 +35,11 @@ type PollerConfig struct {
 	// MaxBackoff caps the exponential backoff (default 30s).
 	MaxBackoff time.Duration
 
-	// OnError is called when a non-fatal error occurs (poll failure,
-	// event processing error, status update failure). If nil, errors
-	// are silently ignored. The Poller continues regardless.
+	// Timeout for individual HTTP requests (default 30s).
+	HTTPTimeout time.Duration
+
+	// OnError is an optional callback invoked when a non-fatal error occurs
+	// (poll failure, event processing error, status update failure).
 	OnError func(err error, msg string)
 }
 
@@ -44,6 +50,7 @@ func DefaultPollerConfig() PollerConfig {
 		PollLimit:      100,
 		InitialBackoff: 1 * time.Second,
 		MaxBackoff:     30 * time.Second,
+		HTTPTimeout:    30 * time.Second,
 	}
 }
 
@@ -60,7 +67,21 @@ type Poller struct {
 
 // NewPoller creates a Poller. controllerName must be the canonical ID
 // from the registered-controller config (e.g., "app-orch-tenant-controller").
-func NewPoller(tenantManagerURL, controllerName string, handler Handler, opts ...func(*PollerConfig)) *Poller {
+// The internal /v1/events and /v1/status endpoints require no auth token —
+// they are ClusterIP-only and the Tenant Manager enforces in-cluster network
+// policy rather than JWT validation on these routes.
+//
+// Returns an error if tenantManagerURL or controllerName is empty.
+func NewPoller(tenantManagerURL, controllerName string, handler Handler, opts ...func(*PollerConfig)) (*Poller, error) {
+	if tenantManagerURL == "" {
+		return nil, fmt.Errorf("tenantManagerURL must not be empty")
+	}
+	if controllerName == "" {
+		return nil, fmt.Errorf("controllerName must not be empty")
+	}
+	if handler == nil {
+		return nil, fmt.Errorf("handler must not be nil")
+	}
 	cfg := DefaultPollerConfig()
 	for _, opt := range opts {
 		opt(&cfg)
@@ -70,19 +91,23 @@ func NewPoller(tenantManagerURL, controllerName string, handler Handler, opts ..
 		controllerName:   controllerName,
 		handler:          handler,
 		config:           cfg,
-		client:           &http.Client{Timeout: 30 * time.Second},
-	}
+		client:           &http.Client{Timeout: cfg.HTTPTimeout},
+	}, nil
 }
 
 // Run executes replay (Phase 1), then enters steady-state polling
 // (Phase 2). Blocks until ctx is cancelled. On restart, replays from
 // scratch. Handlers must be idempotent.
 func (p *Poller) Run(ctx context.Context) error {
+	log.Infof("tenancy poller starting: controller=%s url=%s", p.controllerName, p.tenantManagerURL)
+
 	// Phase 1: Replay with backoff retry.
 	lastEventID, err := p.replayWithRetry(ctx)
 	if err != nil {
 		return err
 	}
+
+	log.Infof("tenancy poller replay complete: controller=%s lastEventId=%d", p.controllerName, lastEventID)
 
 	// Phase 2: Steady-state polling.
 	ticker := time.NewTicker(p.config.PollInterval)
@@ -91,6 +116,7 @@ func (p *Poller) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			log.Infof("tenancy poller stopping: controller=%s", p.controllerName)
 			return ctx.Err()
 		case <-ticker.C:
 			newLastID, err := p.poll(ctx, lastEventID)
@@ -114,7 +140,7 @@ func (p *Poller) replayWithRetry(ctx context.Context) (int64, error) {
 			return lastEventID, nil
 		}
 
-		p.logError(err, fmt.Sprintf("replay failed, retrying in %s", backoff))
+		p.logError(err, fmt.Sprintf("replay failed (controller=%s), retrying in %s", p.controllerName, backoff))
 
 		select {
 		case <-ctx.Done():
@@ -131,18 +157,21 @@ func (p *Poller) replayWithRetry(ctx context.Context) (int64, error) {
 
 // replay fetches synthesized events and processes them.
 func (p *Poller) replay(ctx context.Context) (int64, error) {
-	url := fmt.Sprintf("%s/v1/events?controller=%s&replay=true",
-		p.tenantManagerURL, p.controllerName)
+	tmURL := fmt.Sprintf("%s/v1/events?controller=%s&replay=true",
+		p.tenantManagerURL, url.QueryEscape(p.controllerName))
 
-	resp, err := p.doGet(ctx, url)
+	resp, err := p.doGet(ctx, tmURL)
 	if err != nil {
 		return 0, err
 	}
 
+	log.Debugf("tenancy replay: controller=%s events=%d lastEventId=%d",
+		p.controllerName, len(resp.Events), resp.LastEventID)
+
 	for _, event := range resp.Events {
 		if err := p.processEvent(ctx, event); err != nil {
-			p.logError(err, fmt.Sprintf("replay event %s %s/%s failed",
-				event.EventType, event.ResourceType, event.ResourceName))
+			p.logError(err, fmt.Sprintf("replay event %s %s/%s failed (controller=%s)",
+				event.EventType, event.ResourceType, event.ResourceName, p.controllerName))
 		}
 	}
 
@@ -151,18 +180,23 @@ func (p *Poller) replay(ctx context.Context) (int64, error) {
 
 // poll fetches incremental events after lastEventID and processes them.
 func (p *Poller) poll(ctx context.Context, lastEventID int64) (int64, error) {
-	url := fmt.Sprintf("%s/v1/events?controller=%s&after=%d&limit=%d",
-		p.tenantManagerURL, p.controllerName, lastEventID, p.config.PollLimit)
+	tmURL := fmt.Sprintf("%s/v1/events?controller=%s&after=%d&limit=%d",
+		p.tenantManagerURL, url.QueryEscape(p.controllerName), lastEventID, p.config.PollLimit)
 
-	resp, err := p.doGet(ctx, url)
+	resp, err := p.doGet(ctx, tmURL)
 	if err != nil {
 		return lastEventID, err
 	}
 
+	if len(resp.Events) > 0 {
+		log.Debugf("tenancy poll: controller=%s new_events=%d lastEventId=%d",
+			p.controllerName, len(resp.Events), resp.LastEventID)
+	}
+
 	for _, event := range resp.Events {
 		if err := p.processEvent(ctx, event); err != nil {
-			p.logError(err, fmt.Sprintf("event %s %s/%s failed",
-				event.EventType, event.ResourceType, event.ResourceName))
+			p.logError(err, fmt.Sprintf("event %s %s/%s failed (controller=%s)",
+				event.EventType, event.ResourceType, event.ResourceName, p.controllerName))
 		}
 	}
 
@@ -172,33 +206,42 @@ func (p *Poller) poll(ctx context.Context, lastEventID int64) (int64, error) {
 // processEvent handles a single event: set in_progress, call handler,
 // then update status or delete status row.
 func (p *Poller) processEvent(ctx context.Context, event Event) error {
+	log.Debugf("tenancy processEvent: controller=%s type=%s/%s resource=%s id=%d",
+		p.controllerName, event.ResourceType, event.EventType, event.ResourceName, event.ID)
+
 	// Set status to in_progress.
-	if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, "in_progress", ""); err != nil {
-		p.logError(err, "failed to set in_progress status")
+	if err := p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusInProgress, ""); err != nil {
+		p.logError(err, fmt.Sprintf("failed to set in_progress status for %s/%s (controller=%s)",
+			event.ResourceType, event.ResourceName, p.controllerName))
 	}
 
-	// Call the controller's handler.
+	// Call the controller's handler, wrapping any error with event context.
 	handleErr := p.handler.HandleEvent(ctx, event)
+	if handleErr != nil {
+		handleErr = fmt.Errorf("handle %s %s/%s: %w",
+			event.EventType, event.ResourceType, event.ResourceName, handleErr)
+	}
 
-	if event.EventType == "deleted" {
+	if event.EventType == EventTypeDeleted {
 		if handleErr == nil {
-			// Success: delete the status row.
+			// Success: delete the status row (analogous to DeleteActiveWatchers in Nexus).
 			return p.deleteStatus(ctx, event.ResourceType, event.ResourceID)
 		}
-		// Error on delete: set error status (don't delete the row).
-		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, "error", handleErr.Error())
+		// Error on delete: set error status (row remains for visibility).
+		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error())
 		return handleErr
 	}
 
 	// Created event.
 	if handleErr != nil {
-		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, "error", handleErr.Error())
+		_ = p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusError, handleErr.Error())
 		return handleErr
 	}
-	return p.updateStatus(ctx, event.ResourceType, event.ResourceID, "completed", "")
+	return p.updateStatus(ctx, event.ResourceType, event.ResourceID, StatusCompleted, "")
 }
 
 func (p *Poller) logError(err error, msg string) {
+	log.Warnf("tenancy poller: %s: %v", msg, err)
 	if p.config.OnError != nil {
 		p.config.OnError(err, msg)
 	}
@@ -206,8 +249,8 @@ func (p *Poller) logError(err error, msg string) {
 
 // --- HTTP helpers ---
 
-func (p *Poller) doGet(ctx context.Context, url string) (*eventsResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func (p *Poller) doGet(ctx context.Context, reqURL string) (*eventsResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -250,13 +293,13 @@ func (p *Poller) deleteStatus(ctx context.Context, resourceType string, resource
 	return p.doJSON(ctx, http.MethodDelete, p.tenantManagerURL+"/v1/status", body)
 }
 
-func (p *Poller) doJSON(ctx context.Context, method, url string, body interface{}) error {
+func (p *Poller) doJSON(ctx context.Context, method, reqURL string, body interface{}) error {
 	data, err := json.Marshal(body)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}

--- a/go/pkg/tenancy/poller_test.go
+++ b/go/pkg/tenancy/poller_test.go
@@ -356,10 +356,10 @@ func TestPoller_Poll_AdvancesLastEventID(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(incrementalResp)
 	})
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	srv := httptest.NewServer(mux)

--- a/go/pkg/tenancy/poller_test.go
+++ b/go/pkg/tenancy/poller_test.go
@@ -5,480 +5,528 @@
 package tenancy
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"sync/atomic"
-	"testing"
-	"time"
+"context"
+"encoding/json"
+"errors"
+"fmt"
+"net/http"
+"net/http/httptest"
+"sync/atomic"
+"testing"
+"time"
 
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+"github.com/google/uuid"
+"github.com/stretchr/testify/assert"
+"github.com/stretchr/testify/require"
 )
 
 // recordingHandler records every event it receives and optionally returns an error.
 type recordingHandler struct {
-	events []Event
-	errFn  func(Event) error
+events []Event
+errFn  func(Event) error
 }
 
 func (h *recordingHandler) HandleEvent(_ context.Context, e Event) error {
-	h.events = append(h.events, e)
-	if h.errFn != nil {
-		return h.errFn(e)
-	}
-	return nil
+h.events = append(h.events, e)
+if h.errFn != nil {
+return h.errFn(e)
+}
+return nil
 }
 
 // makeEventsServer builds a test HTTP server that serves event payloads and
 // records PUT/DELETE /v1/status calls.
 type statusCall struct {
-	method string
-	body   map[string]interface{}
+method string
+body   map[string]interface{}
 }
 
 type testServer struct {
-	*httptest.Server
-	statusCalls []statusCall
+*httptest.Server
+statusCalls []statusCall
 }
 
 func newTestServer(t *testing.T, eventsPayloads map[string]eventsResponse) *testServer {
-	t.Helper()
-	ts := &testServer{}
+t.Helper()
+ts := &testServer{}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-		key := r.URL.RawQuery
-		payload, ok := eventsPayloads[key]
-		if !ok {
-			// Default: empty events, lastEventId=0
-			payload = eventsResponse{}
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(payload)
-	})
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+key := r.URL.RawQuery
+payload, ok := eventsPayloads[key]
+if !ok {
+// Default: empty events, lastEventId=0
+payload = eventsResponse{}
+}
+w.Header().Set("Content-Type", "application/json")
+_ = json.NewEncoder(w).Encode(payload)
+})
 
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		ts.statusCalls = append(ts.statusCalls, statusCall{method: r.Method, body: body})
-		w.WriteHeader(http.StatusOK)
-	})
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+var body map[string]interface{}
+_ = json.NewDecoder(r.Body).Decode(&body)
+ts.statusCalls = append(ts.statusCalls, statusCall{method: r.Method, body: body})
+w.WriteHeader(http.StatusOK)
+})
 
-	ts.Server = httptest.NewServer(mux)
-	return ts
+ts.Server = httptest.NewServer(mux)
+return ts
+}
+
+// mustPoller creates a Poller for tests, failing fast if construction fails.
+func mustPoller(t *testing.T, serverURL, name string, h Handler, opts ...func(*PollerConfig)) *Poller {
+t.Helper()
+p, err := NewPoller(serverURL, name, h, opts...)
+require.NoError(t, err)
+return p
 }
 
 // ─── DefaultPollerConfig ────────────────────────────────────────────────────
 
 func TestDefaultPollerConfig(t *testing.T) {
-	cfg := DefaultPollerConfig()
-	assert.Equal(t, 5*time.Second, cfg.PollInterval)
-	assert.Equal(t, 100, cfg.PollLimit)
-	assert.Equal(t, 1*time.Second, cfg.InitialBackoff)
-	assert.Equal(t, 30*time.Second, cfg.MaxBackoff)
+cfg := DefaultPollerConfig()
+assert.Equal(t, 5*time.Second, cfg.PollInterval)
+assert.Equal(t, 100, cfg.PollLimit)
+assert.Equal(t, 1*time.Second, cfg.InitialBackoff)
+assert.Equal(t, 30*time.Second, cfg.MaxBackoff)
 }
 
-// ─── NewPoller ───────────────────────────────────────────────────────────────
+// ─── NewPoller validation ────────────────────────────────────────────────────
 
 func TestNewPoller_AppliesOptions(t *testing.T) {
-	h := &recordingHandler{}
-	p := NewPoller("http://localhost", "my-ctrl", h, func(cfg *PollerConfig) {
-		cfg.PollInterval = 42 * time.Second
-		cfg.PollLimit = 7
-	})
-	assert.Equal(t, 42*time.Second, p.config.PollInterval)
-	assert.Equal(t, 7, p.config.PollLimit)
-	assert.Equal(t, "my-ctrl", p.controllerName)
+h := &recordingHandler{}
+p, err := NewPoller("http://localhost", "my-ctrl", h, func(cfg *PollerConfig) {
+cfg.PollInterval = 42 * time.Second
+cfg.PollLimit = 7
+})
+require.NoError(t, err)
+assert.Equal(t, 42*time.Second, p.config.PollInterval)
+assert.Equal(t, 7, p.config.PollLimit)
+assert.Equal(t, "my-ctrl", p.controllerName)
+}
+
+func TestNewPoller_RejectsEmptyURL(t *testing.T) {
+_, err := NewPoller("", "my-ctrl", &recordingHandler{})
+require.Error(t, err)
+assert.Contains(t, err.Error(), "tenantManagerURL")
+}
+
+func TestNewPoller_RejectsEmptyControllerName(t *testing.T) {
+_, err := NewPoller("http://localhost", "", &recordingHandler{})
+require.Error(t, err)
+assert.Contains(t, err.Error(), "controllerName")
+}
+
+func TestNewPoller_RejectsNilHandler(t *testing.T) {
+_, err := NewPoller("http://localhost", "my-ctrl", nil)
+require.Error(t, err)
+assert.Contains(t, err.Error(), "handler")
 }
 
 // ─── replay: happy path ──────────────────────────────────────────────────────
 
 func TestPoller_Replay_ProcessesEvents(t *testing.T) {
-	id1 := uuid.New()
-	id2 := uuid.New()
-	orgID := uuid.New()
-	orgName := "my-org"
+id1 := uuid.New()
+id2 := uuid.New()
+orgID := uuid.New()
+orgName := "my-org"
 
-	replayResp := eventsResponse{
-		LastEventID: 2,
-		Events: []Event{
-			{
-				ID: 1, EventType: "created", ResourceType: "org",
-				ResourceID: id1, ResourceName: "my-org", CreatedAt: time.Now(),
-			},
-			{
-				ID: 2, EventType: "created", ResourceType: "project",
-				ResourceID: id2, ResourceName: "my-project",
-				OrgID: &orgID, OrgName: &orgName, CreatedAt: time.Now(),
-			},
-		},
-	}
+replayResp := eventsResponse{
+LastEventID: 2,
+Events: []Event{
+{
+ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg,
+ResourceID: id1, ResourceName: "my-org", CreatedAt: time.Now(),
+},
+{
+ID: 2, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+ResourceID: id2, ResourceName: "my-project",
+OrgID: &orgID, OrgName: &orgName, CreatedAt: time.Now(),
+},
+},
+}
 
-	srv := newTestServer(t, map[string]eventsResponse{
-		"controller=test-ctrl&replay=true": replayResp,
-	})
-	defer srv.Close()
+srv := newTestServer(t, map[string]eventsResponse{
+"controller=test-ctrl&replay=true": replayResp,
+})
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "test-ctrl", h)
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "test-ctrl", h)
 
-	lastID, err := p.replay(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(2), lastID)
-	require.Len(t, h.events, 2)
-	assert.Equal(t, "my-org", h.events[0].ResourceName)
-	assert.Equal(t, "my-project", h.events[1].ResourceName)
+lastID, err := p.replay(context.Background())
+require.NoError(t, err)
+assert.Equal(t, int64(2), lastID)
+require.Len(t, h.events, 2)
+assert.Equal(t, "my-org", h.events[0].ResourceName)
+assert.Equal(t, "my-project", h.events[1].ResourceName)
 }
 
 // ─── replay: status updates via processEvent ─────────────────────────────────
 
 func TestPoller_ProcessEvent_CreatedSuccess(t *testing.T) {
-	id := uuid.New()
-	event := Event{
-		ID: 1, EventType: "created", ResourceType: "project",
-		ResourceID: id, ResourceName: "proj",
-	}
+id := uuid.New()
+event := Event{
+ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+ResourceID: id, ResourceName: "proj",
+}
 
-	var statusCalls []statusCall
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+var statusCalls []statusCall
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+var body map[string]interface{}
+_ = json.NewDecoder(r.Body).Decode(&body)
+statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h)
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h)
 
-	err := p.processEvent(context.Background(), event)
-	require.NoError(t, err)
+err := p.processEvent(context.Background(), event)
+require.NoError(t, err)
 
-	require.Len(t, statusCalls, 2)
-	assert.Equal(t, http.MethodPut, statusCalls[0].method)
-	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
-	assert.Equal(t, http.MethodPut, statusCalls[1].method)
-	assert.Equal(t, "completed", statusCalls[1].body["status"])
+require.Len(t, statusCalls, 2)
+assert.Equal(t, http.MethodPut, statusCalls[0].method)
+assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+assert.Equal(t, http.MethodPut, statusCalls[1].method)
+assert.Equal(t, StatusCompleted, statusCalls[1].body["status"])
 }
 
 func TestPoller_ProcessEvent_CreatedError(t *testing.T) {
-	id := uuid.New()
-	event := Event{
-		ID: 1, EventType: "created", ResourceType: "project",
-		ResourceID: id, ResourceName: "proj",
-	}
+id := uuid.New()
+event := Event{
+ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+ResourceID: id, ResourceName: "proj",
+}
 
-	var statusCalls []statusCall
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+var statusCalls []statusCall
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+var body map[string]interface{}
+_ = json.NewDecoder(r.Body).Decode(&body)
+statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{errFn: func(Event) error { return errors.New("handler failed") }}
-	p := NewPoller(srv.URL, "ctrl", h)
+h := &recordingHandler{errFn: func(Event) error { return errors.New("handler failed") }}
+p := mustPoller(t, srv.URL, "ctrl", h)
 
-	err := p.processEvent(context.Background(), event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "handler failed")
+err := p.processEvent(context.Background(), event)
+require.Error(t, err)
+assert.Contains(t, err.Error(), "handler failed")
+// Error is wrapped with event context.
+assert.Contains(t, err.Error(), "proj")
 
-	require.Len(t, statusCalls, 2)
-	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
-	assert.Equal(t, "error", statusCalls[1].body["status"])
+require.Len(t, statusCalls, 2)
+assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+assert.Equal(t, StatusError, statusCalls[1].body["status"])
 }
 
 func TestPoller_ProcessEvent_DeletedSuccess(t *testing.T) {
-	id := uuid.New()
-	event := Event{
-		ID: 1, EventType: "deleted", ResourceType: "project",
-		ResourceID: id, ResourceName: "proj",
-	}
+id := uuid.New()
+event := Event{
+ID: 1, EventType: EventTypeDeleted, ResourceType: ResourceTypeProject,
+ResourceID: id, ResourceName: "proj",
+}
 
-	var statusCalls []statusCall
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+var statusCalls []statusCall
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+var body map[string]interface{}
+_ = json.NewDecoder(r.Body).Decode(&body)
+statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h)
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h)
 
-	err := p.processEvent(context.Background(), event)
-	require.NoError(t, err)
+err := p.processEvent(context.Background(), event)
+require.NoError(t, err)
 
-	require.Len(t, statusCalls, 2)
-	// First call: in_progress (PUT)
-	assert.Equal(t, http.MethodPut, statusCalls[0].method)
-	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
-	// Second call: DELETE (no status field)
-	assert.Equal(t, http.MethodDelete, statusCalls[1].method)
+require.Len(t, statusCalls, 2)
+// First call: in_progress (PUT)
+assert.Equal(t, http.MethodPut, statusCalls[0].method)
+assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+// Second call: DELETE (no status field)
+assert.Equal(t, http.MethodDelete, statusCalls[1].method)
 }
 
 func TestPoller_ProcessEvent_DeletedError(t *testing.T) {
-	id := uuid.New()
-	event := Event{
-		ID: 1, EventType: "deleted", ResourceType: "project",
-		ResourceID: id, ResourceName: "proj",
-	}
+id := uuid.New()
+event := Event{
+ID: 1, EventType: EventTypeDeleted, ResourceType: ResourceTypeProject,
+ResourceID: id, ResourceName: "proj",
+}
 
-	var statusCalls []statusCall
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+var statusCalls []statusCall
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+var body map[string]interface{}
+_ = json.NewDecoder(r.Body).Decode(&body)
+statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{errFn: func(Event) error { return errors.New("cleanup failed") }}
-	p := NewPoller(srv.URL, "ctrl", h)
+h := &recordingHandler{errFn: func(Event) error { return errors.New("cleanup failed") }}
+p := mustPoller(t, srv.URL, "ctrl", h)
 
-	err := p.processEvent(context.Background(), event)
-	require.Error(t, err)
+err := p.processEvent(context.Background(), event)
+require.Error(t, err)
 
-	require.Len(t, statusCalls, 2)
-	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
-	// On delete error: set error status (PUT, not DELETE)
-	assert.Equal(t, http.MethodPut, statusCalls[1].method)
-	assert.Equal(t, "error", statusCalls[1].body["status"])
+require.Len(t, statusCalls, 2)
+assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+// On delete error: set error status (PUT, not DELETE)
+assert.Equal(t, http.MethodPut, statusCalls[1].method)
+assert.Equal(t, StatusError, statusCalls[1].body["status"])
 }
 
 // ─── poll: incremental events ───────────────────────────────────────────────
 
 func TestPoller_Poll_AdvancesLastEventID(t *testing.T) {
-	id := uuid.New()
-	incrementalResp := eventsResponse{
-		LastEventID: 5,
-		Events: []Event{
-			{ID: 5, EventType: "created", ResourceType: "org", ResourceID: id, ResourceName: "org2"},
-		},
-	}
+id := uuid.New()
+incrementalResp := eventsResponse{
+LastEventID: 5,
+Events: []Event{
+{ID: 5, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org2"},
+},
+}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(incrementalResp)
-	})
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+_ = json.NewEncoder(w).Encode(incrementalResp)
+})
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h)
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h)
 
-	newID, err := p.poll(context.Background(), 3)
-	require.NoError(t, err)
-	assert.Equal(t, int64(5), newID)
-	require.Len(t, h.events, 1)
-	assert.Equal(t, "org2", h.events[0].ResourceName)
+newID, err := p.poll(context.Background(), 3)
+require.NoError(t, err)
+assert.Equal(t, int64(5), newID)
+require.Len(t, h.events, 1)
+assert.Equal(t, "org2", h.events[0].ResourceName)
 }
 
 func TestPoller_Poll_PreservesLastIDOnError(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+w.WriteHeader(http.StatusInternalServerError)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h)
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h)
 
-	newID, err := p.poll(context.Background(), 42)
-	require.Error(t, err)
-	assert.Equal(t, int64(42), newID) // unchanged on error
+newID, err := p.poll(context.Background(), 42)
+require.Error(t, err)
+assert.Equal(t, int64(42), newID) // unchanged on error
 }
 
 // ─── replayWithRetry: backoff ────────────────────────────────────────────────
 
 func TestPoller_ReplayWithRetry_SucceedsAfterFailures(t *testing.T) {
-	var callCount atomic.Int32
+var callCount atomic.Int32
 
-	id := uuid.New()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
-		n := callCount.Add(1)
-		if n < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(eventsResponse{
-			LastEventID: 10,
-			Events: []Event{
-				{ID: 10, EventType: "created", ResourceType: "org", ResourceID: id, ResourceName: "org1"},
-			},
-		})
-	})
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+id := uuid.New()
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+n := callCount.Add(1)
+if n < 3 {
+w.WriteHeader(http.StatusServiceUnavailable)
+return
+}
+_ = json.NewEncoder(w).Encode(eventsResponse{
+LastEventID: 10,
+Events: []Event{
+{ID: 10, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org1"},
+},
+})
+})
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	var errMsgs []string
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-		cfg.InitialBackoff = 1 * time.Millisecond
-		cfg.MaxBackoff = 5 * time.Millisecond
-		cfg.OnError = func(_ error, msg string) { errMsgs = append(errMsgs, msg) }
-	})
+var errMsgs []string
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+cfg.InitialBackoff = 1 * time.Millisecond
+cfg.MaxBackoff = 5 * time.Millisecond
+cfg.OnError = func(_ error, msg string) { errMsgs = append(errMsgs, msg) }
+})
 
-	lastID, err := p.replayWithRetry(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, int64(10), lastID)
-	assert.GreaterOrEqual(t, int(callCount.Load()), 3)
-	assert.NotEmpty(t, errMsgs) // errors were reported during retries
+lastID, err := p.replayWithRetry(context.Background())
+require.NoError(t, err)
+assert.Equal(t, int64(10), lastID)
+assert.GreaterOrEqual(t, int(callCount.Load()), 3)
+assert.NotEmpty(t, errMsgs) // errors were reported during retries
 }
 
 func TestPoller_ReplayWithRetry_CancelledContext(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+w.WriteHeader(http.StatusServiceUnavailable)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-		cfg.InitialBackoff = 5 * time.Millisecond
-		cfg.MaxBackoff = 10 * time.Millisecond
-	})
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+cfg.InitialBackoff = 5 * time.Millisecond
+cfg.MaxBackoff = 10 * time.Millisecond
+})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-	defer cancel()
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+defer cancel()
 
-	_, err := p.replayWithRetry(ctx)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+_, err := p.replayWithRetry(ctx)
+require.Error(t, err)
+assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
 }
 
 // ─── Run: end-to-end ─────────────────────────────────────────────────────────
 
 func TestPoller_Run_CancelsCleanly(t *testing.T) {
-	id := uuid.New()
-	replayResp := eventsResponse{
-		LastEventID: 1,
-		Events: []Event{
-			{ID: 1, EventType: "created", ResourceType: "org", ResourceID: id, ResourceName: "org1"},
-		},
-	}
+id := uuid.New()
+replayResp := eventsResponse{
+LastEventID: 1,
+Events: []Event{
+{ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org1"},
+},
+}
 
-	var pollCount atomic.Int32
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("replay") == "true" {
-			_ = json.NewEncoder(w).Encode(replayResp)
-			return
-		}
-		pollCount.Add(1)
-		_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 1})
-	})
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+var pollCount atomic.Int32
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Query().Get("replay") == "true" {
+_ = json.NewEncoder(w).Encode(replayResp)
+return
+}
+pollCount.Add(1)
+_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 1})
+})
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-		cfg.PollInterval = 5 * time.Millisecond
-	})
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+cfg.PollInterval = 5 * time.Millisecond
+})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-	defer cancel()
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+defer cancel()
 
-	err := p.Run(ctx)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+err := p.Run(ctx)
+require.Error(t, err)
+assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
 
-	// Replay processed the one event; steady-state poll ran at least once.
-	require.Len(t, h.events, 1)
-	assert.GreaterOrEqual(t, int(pollCount.Load()), 1)
+// Replay processed the one event; steady-state poll ran at least once.
+require.Len(t, h.events, 1)
+assert.GreaterOrEqual(t, int(pollCount.Load()), 1)
 }
 
 // ─── onError callback ────────────────────────────────────────────────────────
 
 func TestPoller_OnError_CalledOnPollFailure(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("replay") == "true" {
-			_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 0})
-			return
-		}
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprint(w, "internal error")
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Query().Get("replay") == "true" {
+_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 0})
+return
+}
+w.WriteHeader(http.StatusInternalServerError)
+_, _ = fmt.Fprint(w, "internal error")
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	var errorMessages []string
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-		cfg.PollInterval = 5 * time.Millisecond
-		cfg.OnError = func(_ error, msg string) {
-			errorMessages = append(errorMessages, msg)
-		}
-	})
+var errorMessages []string
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+cfg.PollInterval = 5 * time.Millisecond
+cfg.OnError = func(_ error, msg string) {
+errorMessages = append(errorMessages, msg)
+}
+})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
-	defer cancel()
+ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+defer cancel()
 
-	_ = p.Run(ctx)
-	require.NotEmpty(t, errorMessages)
-	assert.Contains(t, errorMessages[0], "poll failed")
+_ = p.Run(ctx)
+require.NotEmpty(t, errorMessages)
+assert.Contains(t, errorMessages[0], "poll failed")
 }
 
 // ─── status request body correctness ────────────────────────────────────────
 
 func TestPoller_StatusRequest_ContainsCorrectFields(t *testing.T) {
-	projectID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-	event := Event{
-		ID: 99, EventType: "created", ResourceType: "project",
-		ResourceID: projectID, ResourceName: "my-proj",
-	}
+projectID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+event := Event{
+ID: 99, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+ResourceID: projectID, ResourceName: "my-proj",
+}
 
-	var puts []map[string]interface{}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPut {
-			var body map[string]interface{}
-			_ = json.NewDecoder(r.Body).Decode(&body)
-			puts = append(puts, body)
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+var puts []map[string]interface{}
+mux := http.NewServeMux()
+mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+if r.Method == http.MethodPut {
+var body map[string]interface{}
+_ = json.NewDecoder(r.Body).Decode(&body)
+puts = append(puts, body)
+}
+w.WriteHeader(http.StatusOK)
+})
+srv := httptest.NewServer(mux)
+defer srv.Close()
 
-	h := &recordingHandler{}
-	p := NewPoller(srv.URL, "my-controller", h)
-	_ = p.processEvent(context.Background(), event)
+h := &recordingHandler{}
+p := mustPoller(t, srv.URL, "my-controller", h)
+_ = p.processEvent(context.Background(), event)
 
-	require.Len(t, puts, 2)
-	for _, put := range puts {
-		assert.Equal(t, "my-controller", put["controller"])
-		assert.Equal(t, "project", put["resourceType"])
-		assert.Equal(t, projectID.String(), put["resourceId"])
-	}
-	assert.Equal(t, "in_progress", puts[0]["status"])
-	assert.Equal(t, "completed", puts[1]["status"])
+require.Len(t, puts, 2)
+for _, put := range puts {
+assert.Equal(t, "my-controller", put["controller"])
+assert.Equal(t, ResourceTypeProject, put["resourceType"])
+assert.Equal(t, projectID.String(), put["resourceId"])
+}
+assert.Equal(t, StatusInProgress, puts[0]["status"])
+assert.Equal(t, StatusCompleted, puts[1]["status"])
+}
+
+// ─── Event.String() ──────────────────────────────────────────────────────────
+
+func TestEvent_String(t *testing.T) {
+id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+e := Event{
+ID:           42,
+EventType:    EventTypeCreated,
+ResourceType: ResourceTypeProject,
+ResourceID:   id,
+ResourceName: "my-proj",
+}
+s := e.String()
+assert.Contains(t, s, "42")
+assert.Contains(t, s, EventTypeCreated)
+assert.Contains(t, s, ResourceTypeProject)
+assert.Contains(t, s, "my-proj")
+assert.Contains(t, s, id.String())
 }

--- a/go/pkg/tenancy/poller_test.go
+++ b/go/pkg/tenancy/poller_test.go
@@ -1,0 +1,484 @@
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tenancy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingHandler records every event it receives and optionally returns an error.
+type recordingHandler struct {
+	events []Event
+	errFn  func(Event) error
+}
+
+func (h *recordingHandler) HandleEvent(_ context.Context, e Event) error {
+	h.events = append(h.events, e)
+	if h.errFn != nil {
+		return h.errFn(e)
+	}
+	return nil
+}
+
+// makeEventsServer builds a test HTTP server that serves event payloads and
+// records PUT/DELETE /v1/status calls.
+type statusCall struct {
+	method string
+	body   map[string]interface{}
+}
+
+type testServer struct {
+	*httptest.Server
+	statusCalls []statusCall
+}
+
+func newTestServer(t *testing.T, eventsPayloads map[string]eventsResponse) *testServer {
+	t.Helper()
+	ts := &testServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.RawQuery
+		payload, ok := eventsPayloads[key]
+		if !ok {
+			// Default: empty events, lastEventId=0
+			payload = eventsResponse{}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		ts.statusCalls = append(ts.statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts.Server = httptest.NewServer(mux)
+	return ts
+}
+
+// ─── DefaultPollerConfig ────────────────────────────────────────────────────
+
+func TestDefaultPollerConfig(t *testing.T) {
+	cfg := DefaultPollerConfig()
+	assert.Equal(t, 5*time.Second, cfg.PollInterval)
+	assert.Equal(t, 100, cfg.PollLimit)
+	assert.Equal(t, 1*time.Second, cfg.InitialBackoff)
+	assert.Equal(t, 30*time.Second, cfg.MaxBackoff)
+}
+
+// ─── NewPoller ───────────────────────────────────────────────────────────────
+
+func TestNewPoller_AppliesOptions(t *testing.T) {
+	h := &recordingHandler{}
+	p := NewPoller("http://localhost", "my-ctrl", h, func(cfg *PollerConfig) {
+		cfg.PollInterval = 42 * time.Second
+		cfg.PollLimit = 7
+	})
+	assert.Equal(t, 42*time.Second, p.config.PollInterval)
+	assert.Equal(t, 7, p.config.PollLimit)
+	assert.Equal(t, "my-ctrl", p.controllerName)
+}
+
+// ─── replay: happy path ──────────────────────────────────────────────────────
+
+func TestPoller_Replay_ProcessesEvents(t *testing.T) {
+	id1 := uuid.New()
+	id2 := uuid.New()
+	orgID := uuid.New()
+	orgName := "my-org"
+
+	replayResp := eventsResponse{
+		LastEventID: 2,
+		Events: []Event{
+			{
+				ID: 1, EventType: "created", ResourceType: "org",
+				ResourceID: id1, ResourceName: "my-org", CreatedAt: time.Now(),
+			},
+			{
+				ID: 2, EventType: "created", ResourceType: "project",
+				ResourceID: id2, ResourceName: "my-project",
+				OrgID: &orgID, OrgName: &orgName, CreatedAt: time.Now(),
+			},
+		},
+	}
+
+	srv := newTestServer(t, map[string]eventsResponse{
+		"controller=test-ctrl&replay=true": replayResp,
+	})
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "test-ctrl", h)
+
+	lastID, err := p.replay(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), lastID)
+	require.Len(t, h.events, 2)
+	assert.Equal(t, "my-org", h.events[0].ResourceName)
+	assert.Equal(t, "my-project", h.events[1].ResourceName)
+}
+
+// ─── replay: status updates via processEvent ─────────────────────────────────
+
+func TestPoller_ProcessEvent_CreatedSuccess(t *testing.T) {
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: "created", ResourceType: "project",
+		ResourceID: id, ResourceName: "proj",
+	}
+
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h)
+
+	err := p.processEvent(context.Background(), event)
+	require.NoError(t, err)
+
+	require.Len(t, statusCalls, 2)
+	assert.Equal(t, http.MethodPut, statusCalls[0].method)
+	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
+	assert.Equal(t, http.MethodPut, statusCalls[1].method)
+	assert.Equal(t, "completed", statusCalls[1].body["status"])
+}
+
+func TestPoller_ProcessEvent_CreatedError(t *testing.T) {
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: "created", ResourceType: "project",
+		ResourceID: id, ResourceName: "proj",
+	}
+
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{errFn: func(Event) error { return errors.New("handler failed") }}
+	p := NewPoller(srv.URL, "ctrl", h)
+
+	err := p.processEvent(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handler failed")
+
+	require.Len(t, statusCalls, 2)
+	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
+	assert.Equal(t, "error", statusCalls[1].body["status"])
+}
+
+func TestPoller_ProcessEvent_DeletedSuccess(t *testing.T) {
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: "deleted", ResourceType: "project",
+		ResourceID: id, ResourceName: "proj",
+	}
+
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h)
+
+	err := p.processEvent(context.Background(), event)
+	require.NoError(t, err)
+
+	require.Len(t, statusCalls, 2)
+	// First call: in_progress (PUT)
+	assert.Equal(t, http.MethodPut, statusCalls[0].method)
+	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
+	// Second call: DELETE (no status field)
+	assert.Equal(t, http.MethodDelete, statusCalls[1].method)
+}
+
+func TestPoller_ProcessEvent_DeletedError(t *testing.T) {
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: "deleted", ResourceType: "project",
+		ResourceID: id, ResourceName: "proj",
+	}
+
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{errFn: func(Event) error { return errors.New("cleanup failed") }}
+	p := NewPoller(srv.URL, "ctrl", h)
+
+	err := p.processEvent(context.Background(), event)
+	require.Error(t, err)
+
+	require.Len(t, statusCalls, 2)
+	assert.Equal(t, "in_progress", statusCalls[0].body["status"])
+	// On delete error: set error status (PUT, not DELETE)
+	assert.Equal(t, http.MethodPut, statusCalls[1].method)
+	assert.Equal(t, "error", statusCalls[1].body["status"])
+}
+
+// ─── poll: incremental events ───────────────────────────────────────────────
+
+func TestPoller_Poll_AdvancesLastEventID(t *testing.T) {
+	id := uuid.New()
+	incrementalResp := eventsResponse{
+		LastEventID: 5,
+		Events: []Event{
+			{ID: 5, EventType: "created", ResourceType: "org", ResourceID: id, ResourceName: "org2"},
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(incrementalResp)
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h)
+
+	newID, err := p.poll(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), newID)
+	require.Len(t, h.events, 1)
+	assert.Equal(t, "org2", h.events[0].ResourceName)
+}
+
+func TestPoller_Poll_PreservesLastIDOnError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h)
+
+	newID, err := p.poll(context.Background(), 42)
+	require.Error(t, err)
+	assert.Equal(t, int64(42), newID) // unchanged on error
+}
+
+// ─── replayWithRetry: backoff ────────────────────────────────────────────────
+
+func TestPoller_ReplayWithRetry_SucceedsAfterFailures(t *testing.T) {
+	var callCount atomic.Int32
+
+	id := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(eventsResponse{
+			LastEventID: 10,
+			Events: []Event{
+				{ID: 10, EventType: "created", ResourceType: "org", ResourceID: id, ResourceName: "org1"},
+			},
+		})
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var errMsgs []string
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.InitialBackoff = 1 * time.Millisecond
+		cfg.MaxBackoff = 5 * time.Millisecond
+		cfg.OnError = func(_ error, msg string) { errMsgs = append(errMsgs, msg) }
+	})
+
+	lastID, err := p.replayWithRetry(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), lastID)
+	assert.GreaterOrEqual(t, int(callCount.Load()), 3)
+	assert.NotEmpty(t, errMsgs) // errors were reported during retries
+}
+
+func TestPoller_ReplayWithRetry_CancelledContext(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.InitialBackoff = 5 * time.Millisecond
+		cfg.MaxBackoff = 10 * time.Millisecond
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := p.replayWithRetry(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+}
+
+// ─── Run: end-to-end ─────────────────────────────────────────────────────────
+
+func TestPoller_Run_CancelsCleanly(t *testing.T) {
+	id := uuid.New()
+	replayResp := eventsResponse{
+		LastEventID: 1,
+		Events: []Event{
+			{ID: 1, EventType: "created", ResourceType: "org", ResourceID: id, ResourceName: "org1"},
+		},
+	}
+
+	var pollCount atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("replay") == "true" {
+			_ = json.NewEncoder(w).Encode(replayResp)
+			return
+		}
+		pollCount.Add(1)
+		_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 1})
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.PollInterval = 5 * time.Millisecond
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err := p.Run(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+
+	// Replay processed the one event; steady-state poll ran at least once.
+	require.Len(t, h.events, 1)
+	assert.GreaterOrEqual(t, int(pollCount.Load()), 1)
+}
+
+// ─── onError callback ────────────────────────────────────────────────────────
+
+func TestPoller_OnError_CalledOnPollFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("replay") == "true" {
+			_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 0})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, "internal error")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var errorMessages []string
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.PollInterval = 5 * time.Millisecond
+		cfg.OnError = func(_ error, msg string) {
+			errorMessages = append(errorMessages, msg)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	_ = p.Run(ctx)
+	require.NotEmpty(t, errorMessages)
+	assert.Contains(t, errorMessages[0], "poll failed")
+}
+
+// ─── status request body correctness ────────────────────────────────────────
+
+func TestPoller_StatusRequest_ContainsCorrectFields(t *testing.T) {
+	projectID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	event := Event{
+		ID: 99, EventType: "created", ResourceType: "project",
+		ResourceID: projectID, ResourceName: "my-proj",
+	}
+
+	var puts []map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			puts = append(puts, body)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := NewPoller(srv.URL, "my-controller", h)
+	_ = p.processEvent(context.Background(), event)
+
+	require.Len(t, puts, 2)
+	for _, put := range puts {
+		assert.Equal(t, "my-controller", put["controller"])
+		assert.Equal(t, "project", put["resourceType"])
+		assert.Equal(t, projectID.String(), put["resourceId"])
+	}
+	assert.Equal(t, "in_progress", puts[0]["status"])
+	assert.Equal(t, "completed", puts[1]["status"])
+}

--- a/go/pkg/tenancy/poller_test.go
+++ b/go/pkg/tenancy/poller_test.go
@@ -249,6 +249,32 @@ func TestPoller_ProcessEvent_CreatedSuccess(t *testing.T) {
 	assert.Equal(t, StatusCompleted, statusCalls[1].body["status"])
 }
 
+func TestPoller_ProcessEvent_RejectsZeroResourceID(t *testing.T) {
+	event := Event{
+		ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+		ResourceID: uuid.Nil, ResourceName: "bad",
+	}
+
+	var statusCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		statusCalls++
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h)
+
+	err := p.processEvent(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zero ResourceID")
+	// Handler must not be invoked, no status writes either.
+	assert.Empty(t, h.events)
+	assert.Equal(t, 0, statusCalls)
+}
+
 func TestPoller_ProcessEvent_CreatedError(t *testing.T) {
 	id := uuid.New()
 	event := Event{

--- a/go/pkg/tenancy/poller_test.go
+++ b/go/pkg/tenancy/poller_test.go
@@ -5,528 +5,582 @@
 package tenancy
 
 import (
-"context"
-"encoding/json"
-"errors"
-"fmt"
-"net/http"
-"net/http/httptest"
-"sync/atomic"
-"testing"
-"time"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
 
-"github.com/google/uuid"
-"github.com/stretchr/testify/assert"
-"github.com/stretchr/testify/require"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // recordingHandler records every event it receives and optionally returns an error.
 type recordingHandler struct {
-events []Event
-errFn  func(Event) error
+	events []Event
+	errFn  func(Event) error
 }
 
 func (h *recordingHandler) HandleEvent(_ context.Context, e Event) error {
-h.events = append(h.events, e)
-if h.errFn != nil {
-return h.errFn(e)
-}
-return nil
+	h.events = append(h.events, e)
+	if h.errFn != nil {
+		return h.errFn(e)
+	}
+	return nil
 }
 
 // makeEventsServer builds a test HTTP server that serves event payloads and
 // records PUT/DELETE /v1/status calls.
 type statusCall struct {
-method string
-body   map[string]interface{}
+	method string
+	body   map[string]interface{}
 }
 
 type testServer struct {
-*httptest.Server
-statusCalls []statusCall
+	*httptest.Server
+	statusCalls []statusCall
 }
 
 func newTestServer(t *testing.T, eventsPayloads map[string]eventsResponse) *testServer {
-t.Helper()
-ts := &testServer{}
+	t.Helper()
+	ts := &testServer{}
 
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-key := r.URL.RawQuery
-payload, ok := eventsPayloads[key]
-if !ok {
-// Default: empty events, lastEventId=0
-payload = eventsResponse{}
-}
-w.Header().Set("Content-Type", "application/json")
-_ = json.NewEncoder(w).Encode(payload)
-})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.RawQuery
+		payload, ok := eventsPayloads[key]
+		if !ok {
+			// Default: empty events, lastEventId=0
+			payload = eventsResponse{}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
 
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-var body map[string]interface{}
-_ = json.NewDecoder(r.Body).Decode(&body)
-ts.statusCalls = append(ts.statusCalls, statusCall{method: r.Method, body: body})
-w.WriteHeader(http.StatusOK)
-})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		ts.statusCalls = append(ts.statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
 
-ts.Server = httptest.NewServer(mux)
-return ts
+	ts.Server = httptest.NewServer(mux)
+	return ts
 }
 
 // mustPoller creates a Poller for tests, failing fast if construction fails.
 func mustPoller(t *testing.T, serverURL, name string, h Handler, opts ...func(*PollerConfig)) *Poller {
-t.Helper()
-p, err := NewPoller(serverURL, name, h, opts...)
-require.NoError(t, err)
-return p
+	t.Helper()
+	p, err := NewPoller(serverURL, name, h, opts...)
+	require.NoError(t, err)
+	return p
 }
 
 // ─── DefaultPollerConfig ────────────────────────────────────────────────────
 
 func TestDefaultPollerConfig(t *testing.T) {
-cfg := DefaultPollerConfig()
-assert.Equal(t, 5*time.Second, cfg.PollInterval)
-assert.Equal(t, 100, cfg.PollLimit)
-assert.Equal(t, 1*time.Second, cfg.InitialBackoff)
-assert.Equal(t, 30*time.Second, cfg.MaxBackoff)
+	cfg := DefaultPollerConfig()
+	assert.Equal(t, 5*time.Second, cfg.PollInterval)
+	assert.Equal(t, 100, cfg.PollLimit)
+	assert.Equal(t, 1*time.Second, cfg.InitialBackoff)
+	assert.Equal(t, 30*time.Second, cfg.MaxBackoff)
 }
 
 // ─── NewPoller validation ────────────────────────────────────────────────────
 
 func TestNewPoller_AppliesOptions(t *testing.T) {
-h := &recordingHandler{}
-p, err := NewPoller("http://localhost", "my-ctrl", h, func(cfg *PollerConfig) {
-cfg.PollInterval = 42 * time.Second
-cfg.PollLimit = 7
-})
-require.NoError(t, err)
-assert.Equal(t, 42*time.Second, p.config.PollInterval)
-assert.Equal(t, 7, p.config.PollLimit)
-assert.Equal(t, "my-ctrl", p.controllerName)
+	h := &recordingHandler{}
+	p, err := NewPoller("http://localhost", "my-ctrl", h, func(cfg *PollerConfig) {
+		cfg.PollInterval = 42 * time.Second
+		cfg.PollLimit = 7
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42*time.Second, p.config.PollInterval)
+	assert.Equal(t, 7, p.config.PollLimit)
+	assert.Equal(t, "my-ctrl", p.controllerName)
 }
 
 func TestNewPoller_RejectsEmptyURL(t *testing.T) {
-_, err := NewPoller("", "my-ctrl", &recordingHandler{})
-require.Error(t, err)
-assert.Contains(t, err.Error(), "tenantManagerURL")
+	_, err := NewPoller("", "my-ctrl", &recordingHandler{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenantManagerURL")
 }
 
 func TestNewPoller_RejectsEmptyControllerName(t *testing.T) {
-_, err := NewPoller("http://localhost", "", &recordingHandler{})
-require.Error(t, err)
-assert.Contains(t, err.Error(), "controllerName")
+	_, err := NewPoller("http://localhost", "", &recordingHandler{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controllerName")
 }
 
 func TestNewPoller_RejectsNilHandler(t *testing.T) {
-_, err := NewPoller("http://localhost", "my-ctrl", nil)
-require.Error(t, err)
-assert.Contains(t, err.Error(), "handler")
+	_, err := NewPoller("http://localhost", "my-ctrl", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handler")
+}
+
+func TestNewPoller_ValidatesConfig(t *testing.T) {
+	h := &recordingHandler{}
+
+	tests := []struct {
+		name      string
+		opt       func(*PollerConfig)
+		expectErr string
+	}{
+		{
+			name: "negative poll interval",
+			opt: func(c *PollerConfig) {
+				c.PollInterval = -1 * time.Second
+			},
+			expectErr: "PollInterval must be positive",
+		},
+		{
+			name: "zero poll limit",
+			opt: func(c *PollerConfig) {
+				c.PollLimit = 0
+			},
+			expectErr: "PollLimit must be positive",
+		},
+		{
+			name: "negative initial backoff",
+			opt: func(c *PollerConfig) {
+				c.InitialBackoff = -1 * time.Second
+			},
+			expectErr: "InitialBackoff must be positive",
+		},
+		{
+			name: "zero max backoff",
+			opt: func(c *PollerConfig) {
+				c.MaxBackoff = 0
+			},
+			expectErr: "MaxBackoff must be positive",
+		},
+		{
+			name: "negative http timeout",
+			opt: func(c *PollerConfig) {
+				c.HTTPTimeout = -5 * time.Second
+			},
+			expectErr: "HTTPTimeout must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPoller("http://tm", "ctrl", h, tt.opt)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectErr)
+		})
+	}
 }
 
 // ─── replay: happy path ──────────────────────────────────────────────────────
 
 func TestPoller_Replay_ProcessesEvents(t *testing.T) {
-id1 := uuid.New()
-id2 := uuid.New()
-orgID := uuid.New()
-orgName := "my-org"
+	id1 := uuid.New()
+	id2 := uuid.New()
+	orgID := uuid.New()
+	orgName := "my-org"
 
-replayResp := eventsResponse{
-LastEventID: 2,
-Events: []Event{
-{
-ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg,
-ResourceID: id1, ResourceName: "my-org", CreatedAt: time.Now(),
-},
-{
-ID: 2, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
-ResourceID: id2, ResourceName: "my-project",
-OrgID: &orgID, OrgName: &orgName, CreatedAt: time.Now(),
-},
-},
-}
+	replayResp := eventsResponse{
+		LastEventID: 2,
+		Events: []Event{
+			{
+				ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg,
+				ResourceID: id1, ResourceName: "my-org", CreatedAt: time.Now(),
+			},
+			{
+				ID: 2, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+				ResourceID: id2, ResourceName: "my-project",
+				OrgID: &orgID, OrgName: &orgName, CreatedAt: time.Now(),
+			},
+		},
+	}
 
-srv := newTestServer(t, map[string]eventsResponse{
-"controller=test-ctrl&replay=true": replayResp,
-})
-defer srv.Close()
+	srv := newTestServer(t, map[string]eventsResponse{
+		"controller=test-ctrl&replay=true": replayResp,
+	})
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "test-ctrl", h)
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "test-ctrl", h)
 
-lastID, err := p.replay(context.Background())
-require.NoError(t, err)
-assert.Equal(t, int64(2), lastID)
-require.Len(t, h.events, 2)
-assert.Equal(t, "my-org", h.events[0].ResourceName)
-assert.Equal(t, "my-project", h.events[1].ResourceName)
+	lastID, err := p.replay(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), lastID)
+	require.Len(t, h.events, 2)
+	assert.Equal(t, "my-org", h.events[0].ResourceName)
+	assert.Equal(t, "my-project", h.events[1].ResourceName)
 }
 
 // ─── replay: status updates via processEvent ─────────────────────────────────
 
 func TestPoller_ProcessEvent_CreatedSuccess(t *testing.T) {
-id := uuid.New()
-event := Event{
-ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
-ResourceID: id, ResourceName: "proj",
-}
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+		ResourceID: id, ResourceName: "proj",
+	}
 
-var statusCalls []statusCall
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-var body map[string]interface{}
-_ = json.NewDecoder(r.Body).Decode(&body)
-statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h)
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h)
 
-err := p.processEvent(context.Background(), event)
-require.NoError(t, err)
+	err := p.processEvent(context.Background(), event)
+	require.NoError(t, err)
 
-require.Len(t, statusCalls, 2)
-assert.Equal(t, http.MethodPut, statusCalls[0].method)
-assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
-assert.Equal(t, http.MethodPut, statusCalls[1].method)
-assert.Equal(t, StatusCompleted, statusCalls[1].body["status"])
+	require.Len(t, statusCalls, 2)
+	assert.Equal(t, http.MethodPut, statusCalls[0].method)
+	assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+	assert.Equal(t, http.MethodPut, statusCalls[1].method)
+	assert.Equal(t, StatusCompleted, statusCalls[1].body["status"])
 }
 
 func TestPoller_ProcessEvent_CreatedError(t *testing.T) {
-id := uuid.New()
-event := Event{
-ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
-ResourceID: id, ResourceName: "proj",
-}
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+		ResourceID: id, ResourceName: "proj",
+	}
 
-var statusCalls []statusCall
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-var body map[string]interface{}
-_ = json.NewDecoder(r.Body).Decode(&body)
-statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{errFn: func(Event) error { return errors.New("handler failed") }}
-p := mustPoller(t, srv.URL, "ctrl", h)
+	h := &recordingHandler{errFn: func(Event) error { return errors.New("handler failed") }}
+	p := mustPoller(t, srv.URL, "ctrl", h)
 
-err := p.processEvent(context.Background(), event)
-require.Error(t, err)
-assert.Contains(t, err.Error(), "handler failed")
-// Error is wrapped with event context.
-assert.Contains(t, err.Error(), "proj")
+	err := p.processEvent(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handler failed")
+	// Error is wrapped with event context.
+	assert.Contains(t, err.Error(), "proj")
 
-require.Len(t, statusCalls, 2)
-assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
-assert.Equal(t, StatusError, statusCalls[1].body["status"])
+	require.Len(t, statusCalls, 2)
+	assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+	assert.Equal(t, StatusError, statusCalls[1].body["status"])
 }
 
 func TestPoller_ProcessEvent_DeletedSuccess(t *testing.T) {
-id := uuid.New()
-event := Event{
-ID: 1, EventType: EventTypeDeleted, ResourceType: ResourceTypeProject,
-ResourceID: id, ResourceName: "proj",
-}
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: EventTypeDeleted, ResourceType: ResourceTypeProject,
+		ResourceID: id, ResourceName: "proj",
+	}
 
-var statusCalls []statusCall
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-var body map[string]interface{}
-_ = json.NewDecoder(r.Body).Decode(&body)
-statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h)
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h)
 
-err := p.processEvent(context.Background(), event)
-require.NoError(t, err)
+	err := p.processEvent(context.Background(), event)
+	require.NoError(t, err)
 
-require.Len(t, statusCalls, 2)
-// First call: in_progress (PUT)
-assert.Equal(t, http.MethodPut, statusCalls[0].method)
-assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
-// Second call: DELETE (no status field)
-assert.Equal(t, http.MethodDelete, statusCalls[1].method)
+	require.Len(t, statusCalls, 2)
+	// First call: in_progress (PUT)
+	assert.Equal(t, http.MethodPut, statusCalls[0].method)
+	assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+	// Second call: DELETE (no status field)
+	assert.Equal(t, http.MethodDelete, statusCalls[1].method)
 }
 
 func TestPoller_ProcessEvent_DeletedError(t *testing.T) {
-id := uuid.New()
-event := Event{
-ID: 1, EventType: EventTypeDeleted, ResourceType: ResourceTypeProject,
-ResourceID: id, ResourceName: "proj",
-}
+	id := uuid.New()
+	event := Event{
+		ID: 1, EventType: EventTypeDeleted, ResourceType: ResourceTypeProject,
+		ResourceID: id, ResourceName: "proj",
+	}
 
-var statusCalls []statusCall
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-var body map[string]interface{}
-_ = json.NewDecoder(r.Body).Decode(&body)
-statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	var statusCalls []statusCall
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		statusCalls = append(statusCalls, statusCall{method: r.Method, body: body})
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{errFn: func(Event) error { return errors.New("cleanup failed") }}
-p := mustPoller(t, srv.URL, "ctrl", h)
+	h := &recordingHandler{errFn: func(Event) error { return errors.New("cleanup failed") }}
+	p := mustPoller(t, srv.URL, "ctrl", h)
 
-err := p.processEvent(context.Background(), event)
-require.Error(t, err)
+	err := p.processEvent(context.Background(), event)
+	require.Error(t, err)
 
-require.Len(t, statusCalls, 2)
-assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
-// On delete error: set error status (PUT, not DELETE)
-assert.Equal(t, http.MethodPut, statusCalls[1].method)
-assert.Equal(t, StatusError, statusCalls[1].body["status"])
+	require.Len(t, statusCalls, 2)
+	assert.Equal(t, StatusInProgress, statusCalls[0].body["status"])
+	// On delete error: set error status (PUT, not DELETE)
+	assert.Equal(t, http.MethodPut, statusCalls[1].method)
+	assert.Equal(t, StatusError, statusCalls[1].body["status"])
 }
 
 // ─── poll: incremental events ───────────────────────────────────────────────
 
 func TestPoller_Poll_AdvancesLastEventID(t *testing.T) {
-id := uuid.New()
-incrementalResp := eventsResponse{
-LastEventID: 5,
-Events: []Event{
-{ID: 5, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org2"},
-},
-}
+	id := uuid.New()
+	incrementalResp := eventsResponse{
+		LastEventID: 5,
+		Events: []Event{
+			{ID: 5, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org2"},
+		},
+	}
 
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-_ = json.NewEncoder(w).Encode(incrementalResp)
-})
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(incrementalResp)
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h)
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h)
 
-newID, err := p.poll(context.Background(), 3)
-require.NoError(t, err)
-assert.Equal(t, int64(5), newID)
-require.Len(t, h.events, 1)
-assert.Equal(t, "org2", h.events[0].ResourceName)
+	newID, err := p.poll(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), newID)
+	require.Len(t, h.events, 1)
+	assert.Equal(t, "org2", h.events[0].ResourceName)
 }
 
 func TestPoller_Poll_PreservesLastIDOnError(t *testing.T) {
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
-w.WriteHeader(http.StatusInternalServerError)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h)
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h)
 
-newID, err := p.poll(context.Background(), 42)
-require.Error(t, err)
-assert.Equal(t, int64(42), newID) // unchanged on error
+	newID, err := p.poll(context.Background(), 42)
+	require.Error(t, err)
+	assert.Equal(t, int64(42), newID) // unchanged on error
 }
 
 // ─── replayWithRetry: backoff ────────────────────────────────────────────────
 
 func TestPoller_ReplayWithRetry_SucceedsAfterFailures(t *testing.T) {
-var callCount atomic.Int32
+	var callCount atomic.Int32
 
-id := uuid.New()
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
-n := callCount.Add(1)
-if n < 3 {
-w.WriteHeader(http.StatusServiceUnavailable)
-return
-}
-_ = json.NewEncoder(w).Encode(eventsResponse{
-LastEventID: 10,
-Events: []Event{
-{ID: 10, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org1"},
-},
-})
-})
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	id := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(eventsResponse{
+			LastEventID: 10,
+			Events: []Event{
+				{ID: 10, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org1"},
+			},
+		})
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-var errMsgs []string
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-cfg.InitialBackoff = 1 * time.Millisecond
-cfg.MaxBackoff = 5 * time.Millisecond
-cfg.OnError = func(_ error, msg string) { errMsgs = append(errMsgs, msg) }
-})
+	var errMsgs []string
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.InitialBackoff = 1 * time.Millisecond
+		cfg.MaxBackoff = 5 * time.Millisecond
+		cfg.OnError = func(_ error, msg string) { errMsgs = append(errMsgs, msg) }
+	})
 
-lastID, err := p.replayWithRetry(context.Background())
-require.NoError(t, err)
-assert.Equal(t, int64(10), lastID)
-assert.GreaterOrEqual(t, int(callCount.Load()), 3)
-assert.NotEmpty(t, errMsgs) // errors were reported during retries
+	lastID, err := p.replayWithRetry(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), lastID)
+	assert.GreaterOrEqual(t, int(callCount.Load()), 3)
+	assert.NotEmpty(t, errMsgs) // errors were reported during retries
 }
 
 func TestPoller_ReplayWithRetry_CancelledContext(t *testing.T) {
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
-w.WriteHeader(http.StatusServiceUnavailable)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-cfg.InitialBackoff = 5 * time.Millisecond
-cfg.MaxBackoff = 10 * time.Millisecond
-})
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.InitialBackoff = 5 * time.Millisecond
+		cfg.MaxBackoff = 10 * time.Millisecond
+	})
 
-ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
 
-_, err := p.replayWithRetry(ctx)
-require.Error(t, err)
-assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+	_, err := p.replayWithRetry(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
 }
 
 // ─── Run: end-to-end ─────────────────────────────────────────────────────────
 
 func TestPoller_Run_CancelsCleanly(t *testing.T) {
-id := uuid.New()
-replayResp := eventsResponse{
-LastEventID: 1,
-Events: []Event{
-{ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org1"},
-},
-}
+	id := uuid.New()
+	replayResp := eventsResponse{
+		LastEventID: 1,
+		Events: []Event{
+			{ID: 1, EventType: EventTypeCreated, ResourceType: ResourceTypeOrg, ResourceID: id, ResourceName: "org1"},
+		},
+	}
 
-var pollCount atomic.Int32
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-if r.URL.Query().Get("replay") == "true" {
-_ = json.NewEncoder(w).Encode(replayResp)
-return
-}
-pollCount.Add(1)
-_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 1})
-})
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	var pollCount atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("replay") == "true" {
+			_ = json.NewEncoder(w).Encode(replayResp)
+			return
+		}
+		pollCount.Add(1)
+		_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 1})
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-cfg.PollInterval = 5 * time.Millisecond
-})
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.PollInterval = 5 * time.Millisecond
+	})
 
-ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
 
-err := p.Run(ctx)
-require.Error(t, err)
-assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+	err := p.Run(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
 
-// Replay processed the one event; steady-state poll ran at least once.
-require.Len(t, h.events, 1)
-assert.GreaterOrEqual(t, int(pollCount.Load()), 1)
+	// Replay processed the one event; steady-state poll ran at least once.
+	require.Len(t, h.events, 1)
+	assert.GreaterOrEqual(t, int(pollCount.Load()), 1)
 }
 
 // ─── onError callback ────────────────────────────────────────────────────────
 
 func TestPoller_OnError_CalledOnPollFailure(t *testing.T) {
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
-if r.URL.Query().Get("replay") == "true" {
-_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 0})
-return
-}
-w.WriteHeader(http.StatusInternalServerError)
-_, _ = fmt.Fprint(w, "internal error")
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("replay") == "true" {
+			_ = json.NewEncoder(w).Encode(eventsResponse{LastEventID: 0})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, "internal error")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-var errorMessages []string
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
-cfg.PollInterval = 5 * time.Millisecond
-cfg.OnError = func(_ error, msg string) {
-errorMessages = append(errorMessages, msg)
-}
-})
+	var errorMessages []string
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "ctrl", h, func(cfg *PollerConfig) {
+		cfg.PollInterval = 5 * time.Millisecond
+		cfg.OnError = func(_ error, msg string) {
+			errorMessages = append(errorMessages, msg)
+		}
+	})
 
-ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
-defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
 
-_ = p.Run(ctx)
-require.NotEmpty(t, errorMessages)
-assert.Contains(t, errorMessages[0], "poll failed")
+	_ = p.Run(ctx)
+	require.NotEmpty(t, errorMessages)
+	assert.Contains(t, errorMessages[0], "poll failed")
 }
 
 // ─── status request body correctness ────────────────────────────────────────
 
 func TestPoller_StatusRequest_ContainsCorrectFields(t *testing.T) {
-projectID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-event := Event{
-ID: 99, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
-ResourceID: projectID, ResourceName: "my-proj",
-}
+	projectID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	event := Event{
+		ID: 99, EventType: EventTypeCreated, ResourceType: ResourceTypeProject,
+		ResourceID: projectID, ResourceName: "my-proj",
+	}
 
-var puts []map[string]interface{}
-mux := http.NewServeMux()
-mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
-if r.Method == http.MethodPut {
-var body map[string]interface{}
-_ = json.NewDecoder(r.Body).Decode(&body)
-puts = append(puts, body)
-}
-w.WriteHeader(http.StatusOK)
-})
-srv := httptest.NewServer(mux)
-defer srv.Close()
+	var puts []map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			puts = append(puts, body)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-h := &recordingHandler{}
-p := mustPoller(t, srv.URL, "my-controller", h)
-_ = p.processEvent(context.Background(), event)
+	h := &recordingHandler{}
+	p := mustPoller(t, srv.URL, "my-controller", h)
+	_ = p.processEvent(context.Background(), event)
 
-require.Len(t, puts, 2)
-for _, put := range puts {
-assert.Equal(t, "my-controller", put["controller"])
-assert.Equal(t, ResourceTypeProject, put["resourceType"])
-assert.Equal(t, projectID.String(), put["resourceId"])
-}
-assert.Equal(t, StatusInProgress, puts[0]["status"])
-assert.Equal(t, StatusCompleted, puts[1]["status"])
+	require.Len(t, puts, 2)
+	for _, put := range puts {
+		assert.Equal(t, "my-controller", put["controller"])
+		assert.Equal(t, ResourceTypeProject, put["resourceType"])
+		assert.Equal(t, projectID.String(), put["resourceId"])
+	}
+	assert.Equal(t, StatusInProgress, puts[0]["status"])
+	assert.Equal(t, StatusCompleted, puts[1]["status"])
 }
 
 // ─── Event.String() ──────────────────────────────────────────────────────────
 
 func TestEvent_String(t *testing.T) {
-id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-e := Event{
-ID:           42,
-EventType:    EventTypeCreated,
-ResourceType: ResourceTypeProject,
-ResourceID:   id,
-ResourceName: "my-proj",
-}
-s := e.String()
-assert.Contains(t, s, "42")
-assert.Contains(t, s, EventTypeCreated)
-assert.Contains(t, s, ResourceTypeProject)
-assert.Contains(t, s, "my-proj")
-assert.Contains(t, s, id.String())
+	id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	e := Event{
+		ID:           42,
+		EventType:    EventTypeCreated,
+		ResourceType: ResourceTypeProject,
+		ResourceID:   id,
+		ResourceName: "my-proj",
+	}
+	s := e.String()
+	assert.Contains(t, s, "42")
+	assert.Contains(t, s, EventTypeCreated)
+	assert.Contains(t, s, ResourceTypeProject)
+	assert.Contains(t, s, "my-proj")
+	assert.Contains(t, s, id.String())
 }

--- a/go/pkg/tenancy/tenancy.go
+++ b/go/pkg/tenancy/tenancy.go
@@ -12,24 +12,56 @@ package tenancy
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+// EventType constants for Event.EventType.
+const (
+	EventTypeCreated = "created"
+	EventTypeDeleted = "deleted"
+)
+
+// ResourceType constants for Event.ResourceType.
+const (
+	ResourceTypeOrg     = "org"
+	ResourceTypeProject = "project"
+)
+
+// Status constants used in controller status reporting.
+const (
+	StatusInProgress = "in_progress"
+	StatusCompleted  = "completed"
+	StatusError      = "error"
+)
+
 // Event represents a tenancy lifecycle event. Both replay (synthesized
 // from DB state) and incremental (from tenancy_events) events use the
-// same structure.
+// same structure. Handlers must be idempotent — replay on restart will
+// re-deliver events for all existing and soft-deleted resources.
 type Event struct {
-	ID           int64      `json:"id"`
-	EventType    string     `json:"eventType"`    // "created", "deleted"
-	ResourceType string     `json:"resourceType"` // "org", "project"
-	ResourceID   uuid.UUID  `json:"resourceId"`
-	ResourceName string     `json:"resourceName"`
-	OrgID        *uuid.UUID `json:"orgId"`
-	OrgName      *string    `json:"orgName"`
-	FolderID     *uuid.UUID `json:"folderId"`
-	CreatedAt    time.Time  `json:"createdAt"`
+	// ID is the monotonically increasing event sequence number.
+	ID int64 `json:"id"`
+	// EventType is "created" or "deleted".
+	EventType string `json:"eventType"`
+	// ResourceType is "org" or "project".
+	ResourceType string    `json:"resourceType"`
+	ResourceID   uuid.UUID `json:"resourceId"`
+	ResourceName string    `json:"resourceName"`
+	// OrgID is set for project events; nil for org events.
+	OrgID   *uuid.UUID `json:"orgId"`
+	OrgName *string    `json:"orgName"`
+	// FolderID is reserved for future hierarchical resource types.
+	FolderID  *uuid.UUID `json:"folderId"`
+	CreatedAt time.Time  `json:"createdAt"`
+}
+
+// String returns a summary of the event for logging.
+func (e Event) String() string {
+	return fmt.Sprintf("Event{id=%d type=%s/%s name=%q resourceId=%s}",
+		e.ID, e.ResourceType, e.EventType, e.ResourceName, e.ResourceID)
 }
 
 // Handler is implemented by each controller with its business logic.

--- a/go/pkg/tenancy/tenancy.go
+++ b/go/pkg/tenancy/tenancy.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tenancy provides a shared client library for tenant controllers
+// to consume tenancy events from the Tenant Manager REST API.
+//
+// This package has no database or Ent dependencies -- it is a pure HTTP
+// client. Controllers only need the Tenant Manager URL and their canonical
+// controller name.
+package tenancy
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Event represents a tenancy lifecycle event. Both replay (synthesized
+// from DB state) and incremental (from tenancy_events) events use the
+// same structure.
+type Event struct {
+	ID           int64      `json:"id"`
+	EventType    string     `json:"eventType"`    // "created", "deleted"
+	ResourceType string     `json:"resourceType"` // "org", "project"
+	ResourceID   uuid.UUID  `json:"resourceId"`
+	ResourceName string     `json:"resourceName"`
+	OrgID        *uuid.UUID `json:"orgId"`
+	OrgName      *string    `json:"orgName"`
+	FolderID     *uuid.UUID `json:"folderId"`
+	CreatedAt    time.Time  `json:"createdAt"`
+}
+
+// Handler is implemented by each controller with its business logic.
+type Handler interface {
+	// HandleEvent is called for each event (both replay and incremental).
+	// Must be idempotent -- replay on restart will re-deliver events for
+	// all existing and soft-deleted resources.
+	HandleEvent(ctx context.Context, event Event) error
+}
+
+// eventsResponse is the wire format returned by GET /v1/events.
+type eventsResponse struct {
+	Events      []Event `json:"events"`
+	LastEventID int64   `json:"lastEventId"`
+}
+
+// statusUpdateRequest is the body for PUT /v1/status.
+type statusUpdateRequest struct {
+	Controller   string    `json:"controller"`
+	ResourceType string    `json:"resourceType"`
+	ResourceID   uuid.UUID `json:"resourceId"`
+	Status       string    `json:"status"`
+	Message      string    `json:"message"`
+}
+
+// statusDeleteRequest is the body for DELETE /v1/status.
+type statusDeleteRequest struct {
+	Controller   string    `json:"controller"`
+	ResourceType string    `json:"resourceType"`
+	ResourceID   uuid.UUID `json:"resourceId"`
+}

--- a/go/pkg/tenancy/tenancy.go
+++ b/go/pkg/tenancy/tenancy.go
@@ -64,7 +64,6 @@ func (e Event) String() string {
 		e.ID, e.ResourceType, e.EventType, e.ResourceName, e.ResourceID)
 }
 
-// Handler is implemented by each controller with its business logic.
 type Handler interface {
 	// HandleEvent is called for each event (both replay and incremental).
 	// Must be idempotent -- replay on restart will re-deliver events for


### PR DESCRIPTION
# Description

- Add `go/pkg/tenancy` package: Event type, Handler interface, and Poller with two-phase replay-then-poll lifecycle for consuming Tenant Manager events
- Add config validation in NewPoller() and at-least-once poll semantics (stop at first failure, retry on next interval)
- Update ResolveProjectUUID to call `GET /v1/projects/{name} directly` (O(1) lookup) instead of listing all projects via Nexus API (O(n) scan)
- Add JWT access validation in `ResolveProjectUUID`
- Treat empty project UUID in Tenant Manager 200 response as hard failure instead of silent no-op
- Update `projectcontext` tests to match new single-object response format and valid JWT token structure
- Add comprehensive unit tests for Poller

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [x] Tests passed
- [ ] Documentation updated
