### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -18,3 +20,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request introduces a cooldown period for Dependabot updates in the `.github/dependabot.yml` configuration. This helps reduce noise by limiting how frequently Dependabot will open new pull requests for both Go modules and GitHub Actions dependencies.

Dependabot configuration improvements:

* Added a `cooldown` setting with `default-days: 7` for both the Go modules and GitHub Actions package ecosystems, ensuring that Dependabot waits 7 days before opening new update PRs after the previous ones.