### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-go-dazl-zap.yaml
+++ b/.github/workflows/post-merge-go-dazl-zap.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-go-dazl-zerolog.yaml
+++ b/.github/workflows/post-merge-go-dazl-zerolog.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-go-dazl.yaml
+++ b/.github/workflows/post-merge-go-dazl.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-go.yaml
+++ b/.github/workflows/post-merge-go.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to trigger on tag pushes in addition to branch pushes. This ensures that the workflows will run when a new tag is created, which is useful for release processes.

Workflow trigger updates:

* [`.github/workflows/post-merge-go.yaml`](diffhunk://#diff-dad5a2974c0c708e139171edb3d8620bfb464d5a1f1fadbdb3e986328e9bbf9cR13-R14): Added support for triggering the workflow on any tag push by including a wildcard pattern under `tags`.
* [`.github/workflows/post-merge-go-dazl.yaml`](diffhunk://#diff-1b72b67eca68ae3cbe655070c693fd84db2f757cd258bd6abbecdc7e9c44fdabR13-R14): Added tag trigger support to run the workflow on any tag push.
* [`.github/workflows/post-merge-go-dazl-zap.yaml`](diffhunk://#diff-eaecf0314443d8573119bc5a40e694af29d69533822ed700c49b7e733a67ec2bR13-R14): Updated to trigger the workflow on tag pushes as well as branches.
* [`.github/workflows/post-merge-go-dazl-zerolog.yaml`](diffhunk://#diff-f5c81f4fc4a92189768aca8f1b9ceb87eeaed354afa43b51559d02980ef92889R13-R14): Enabled workflow runs on any tag push by adding a wildcard tag pattern.