### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-go-dazl-zap.yaml
+++ b/.github/workflows/post-merge-go-dazl-zap.yaml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-go-dazl-zerolog.yaml
+++ b/.github/workflows/post-merge-go-dazl-zerolog.yaml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-go-dazl.yaml
+++ b/.github/workflows/post-merge-go-dazl.yaml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-go.yaml
+++ b/.github/workflows/post-merge-go.yaml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to change when the workflows are triggered. The primary change is the removal of workflow triggers based on Git tags, so these workflows will now only run on merges to specific branches or when manually dispatched.

**Workflow trigger updates:**

* Removed the `tags` trigger (which ran workflows on any tag push) from the following workflow files:
  * `.github/workflows/post-merge-go.yaml`
  * `.github/workflows/post-merge-go-dazl.yaml`
  * `.github/workflows/post-merge-go-dazl-zap.yaml`
  * `.github/workflows/post-merge-go-dazl-zerolog.yaml`

As a result, these workflows will now only be triggered by pushes to the `main` or `release-*` branches, or via manual dispatch.